### PR TITLE
Add chat list swipe settings (disable swipe actions / swipe to switch folders)

### DIFF
--- a/lib/chats/chat_list_view.dart
+++ b/lib/chats/chat_list_view.dart
@@ -765,10 +765,9 @@ class _ChatListViewState extends State<ChatListView> {
 
   Widget _chatList() {
     final c = context.colors;
-    final showSearch = context.watch<ThemeController>().showChatListSearch;
-    final assistantPlacement = context
-        .watch<ThemeController>()
-        .groupAssistantPlacement;
+    final theme = context.watch<ThemeController>();
+    final showSearch = theme.showChatListSearch;
+    final assistantPlacement = theme.groupAssistantPlacement;
     return Container(
       color: c.background,
       child: LayoutBuilder(
@@ -836,7 +835,7 @@ class _ChatListViewState extends State<ChatListView> {
               (topAssistant ? 1 : 0) +
               (showSearch ? 1 : 0) +
               (showInlineAssistant ? 1 : 0);
-          return ListView.builder(
+          final list = ListView.builder(
             controller: _scrollController,
             padding:
                 EdgeInsets.zero, // header already consumed the top safe-area
@@ -849,6 +848,16 @@ class _ChatListViewState extends State<ChatListView> {
               showInlineAssistant: showInlineAssistant,
               assistantIndex: assistantIndex,
             ),
+          );
+          if (!theme.chatListFolderSwipeSwitching ||
+              _model.filters.length < 2) {
+            return list;
+          }
+          return GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onHorizontalDragEnd: (details) =>
+                _switchFolderBySwipe(details.primaryVelocity),
+            child: list,
           );
         },
       ),
@@ -879,6 +888,24 @@ class _ChatListViewState extends State<ChatListView> {
     return _swipeRow(chats[chatIndex]);
   }
 
+  void _switchFolderBySwipe(double? velocity) {
+    if (velocity == null || velocity.abs() < 240) return;
+    final filters = _model.filters;
+    if (filters.length < 2) return;
+    final current = filters.indexWhere(
+      (filter) => filter.folderId == _model.selectedFilter.folderId,
+    );
+    if (current < 0) return;
+    final next = velocity < 0 ? current + 1 : current - 1;
+    if (next < 0 || next >= filters.length) return;
+    _model.selectFilter(filters[next]);
+    _scrollController.animateTo(
+      0,
+      duration: const Duration(milliseconds: 180),
+      curve: Curves.easeOutCubic,
+    );
+  }
+
   int _assistantInsertionIndex(
     List<ChatSummary> chats,
     int visibleRows,
@@ -907,6 +934,17 @@ class _ChatListViewState extends State<ChatListView> {
   }
 
   Widget _swipeRow(ChatSummary chat) {
+    if (context.watch<ThemeController>().disableChatListSwipeActions) {
+      return GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => _openChat(chat),
+        child: ChatRowView(
+          chat: chat,
+          selected: widget.selectedChatId == chat.id,
+          onClearUnread: () => _model.markRead(chat),
+        ),
+      );
+    }
     final actions = chat.isPinned
         ? [
             SwipeActionItem(

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -262,6 +262,10 @@ abstract final class AppStringKeys {
   static const appearanceRoundGroupAvatars = 'appearanceRoundGroupAvatars';
   static const appearanceSearchFont = 'appearanceSearchFont';
   static const appearanceShowChatListSearch = 'appearanceShowChatListSearch';
+  static const appearanceDisableChatListSwipeActions =
+      'appearanceDisableChatListSwipeActions';
+  static const appearanceChatListFolderSwipeSwitching =
+      'appearanceChatListFolderSwipeSwitching';
   static const appearanceShowEditAndReadMarks =
       'appearanceShowEditAndReadMarks';
   static const appearanceShowGroupMemberTitles =

--- a/lib/l10n/messages/de.dart
+++ b/lib/l10n/messages/de.dart
@@ -126,6 +126,8 @@ const deMessages = <String, String>{
   'appearanceRefreshCacheList': "Cache-Liste aktualisieren",
   'appearanceRoundGroupAvatars': "Gruppenavatare rund anzeigen",
   'appearanceSearchFont': "Schriftart suchen",
+  'appearanceDisableChatListSwipeActions': 'Chatlisten-Wischaktionen deaktivieren',
+  'appearanceChatListFolderSwipeSwitching': 'Wischen zum Wechseln der Chatordner',
   'appearanceShowChatListSearch': "Chatlistensuche anzeigen",
   'appearanceShowEditAndReadMarks':
       "Bearbeitet- und Gelesen-Markierungen anzeigen",

--- a/lib/l10n/messages/en.dart
+++ b/lib/l10n/messages/en.dart
@@ -123,6 +123,8 @@ const enMessages = <String, String>{
   'appearanceRefreshCacheList': "Refresh Cache List",
   'appearanceRoundGroupAvatars': "Show Group Avatars as Circles",
   'appearanceSearchFont': "Search fonts",
+  'appearanceDisableChatListSwipeActions': 'Disable Chat List Swipe Actions',
+  'appearanceChatListFolderSwipeSwitching': 'Swipe to Switch Chat Folders',
   'appearanceShowChatListSearch': "Show Chat List Search",
   'appearanceShowEditAndReadMarks': "Show Edit and Read Marks",
   'appearanceShowGroupMemberTitles': "Show Group Member Titles",

--- a/lib/l10n/messages/es.dart
+++ b/lib/l10n/messages/es.dart
@@ -124,6 +124,8 @@ const esMessages = <String, String>{
   'appearanceRefreshCacheList': "Actualizar lista de caché",
   'appearanceRoundGroupAvatars': "Mostrar avatares de grupos redondos",
   'appearanceSearchFont': "Buscar fuente",
+  'appearanceDisableChatListSwipeActions': 'Desactivar acciones de deslizamiento en la lista de chats',
+  'appearanceChatListFolderSwipeSwitching': 'Deslizar para cambiar de carpeta de chats',
   'appearanceShowChatListSearch': "Mostrar búsqueda en la lista de chats",
   'appearanceShowEditAndReadMarks': "Mostrar marcas de edición y lectura",
   'appearanceShowGroupMemberTitles': "Mostrar cargos de miembros del grupo",

--- a/lib/l10n/messages/fr.dart
+++ b/lib/l10n/messages/fr.dart
@@ -126,6 +126,8 @@ const frMessages = <String, String>{
   'appearanceRefreshCacheList': "Actualiser la liste du cache",
   'appearanceRoundGroupAvatars': "Afficher les avatars de groupe en cercle",
   'appearanceSearchFont': "Rechercher une police",
+  'appearanceDisableChatListSwipeActions': 'Désactiver les actions de balayage de la liste de chats',
+  'appearanceChatListFolderSwipeSwitching': 'Balayer pour changer de dossier de chats',
   'appearanceShowChatListSearch': "Afficher la recherche dans la liste",
   'appearanceShowEditAndReadMarks':
       "Afficher les marques de modification et de lecture",

--- a/lib/l10n/messages/ja.dart
+++ b/lib/l10n/messages/ja.dart
@@ -120,6 +120,8 @@ const jaMessages = <String, String>{
   'appearanceRefreshCacheList': "キャッシュ一覧を更新",
   'appearanceRoundGroupAvatars': "グループチャットのアイコンを丸く表示",
   'appearanceSearchFont': "フォントを検索",
+  'appearanceDisableChatListSwipeActions': 'チャットリストのスワイプアクションを無効化',
+  'appearanceChatListFolderSwipeSwitching': 'スワイプでチャットフォルダーを切り替え',
   'appearanceShowChatListSearch': "チャットリスト検索を表示",
   'appearanceShowEditAndReadMarks': "編集済み・既読マークを表示",
   'appearanceShowGroupMemberTitles': "グループメンバーの肩書きを表示",

--- a/lib/l10n/messages/ko.dart
+++ b/lib/l10n/messages/ko.dart
@@ -120,6 +120,8 @@ const koMessages = <String, String>{
   'appearanceRefreshCacheList': "캐시 목록 새로 고침",
   'appearanceRoundGroupAvatars': "그룹 채팅 프로필을 원형으로 표시",
   'appearanceSearchFont': "글꼴 검색",
+  'appearanceDisableChatListSwipeActions': '채팅 목록 스와이프 동작 비활성화',
+  'appearanceChatListFolderSwipeSwitching': '스와이프로 채팅 폴더 전환',
   'appearanceShowChatListSearch': "채팅 목록 검색 표시",
   'appearanceShowEditAndReadMarks': "수정 및 읽음 표시 보이기",
   'appearanceShowGroupMemberTitles': "그룹 멤버 직함 표시",

--- a/lib/l10n/messages/zh_hans.dart
+++ b/lib/l10n/messages/zh_hans.dart
@@ -117,6 +117,8 @@ const zhHansMessages = <String, String>{
   'appearanceRefreshCacheList': "刷新缓存列表",
   'appearanceRoundGroupAvatars': "群聊头像显示为圆形",
   'appearanceSearchFont': "搜索字体",
+  'appearanceDisableChatListSwipeActions': '禁用聊天列表侧滑选项',
+  'appearanceChatListFolderSwipeSwitching': '滑动切换聊天文件夹',
   'appearanceShowChatListSearch': "显示聊天列表搜索",
   'appearanceShowEditAndReadMarks': "显示编辑和已读标记",
   'appearanceShowGroupMemberTitles': "群成员显示头衔",

--- a/lib/l10n/messages/zh_hant.dart
+++ b/lib/l10n/messages/zh_hant.dart
@@ -118,6 +118,8 @@ const zhHantMessages = <String, String>{
   'appearanceRefreshCacheList': "重新整理快取列表",
   'appearanceRoundGroupAvatars': "群組頭像顯示為圓形",
   'appearanceSearchFont': "搜尋字型",
+  'appearanceDisableChatListSwipeActions': '禁用聊天列表側滑選項',
+  'appearanceChatListFolderSwipeSwitching': '滑動切換聊天資料夾',
   'appearanceShowChatListSearch': "顯示聊天列表搜尋",
   'appearanceShowEditAndReadMarks': "顯示編輯與已讀標記",
   'appearanceShowGroupMemberTitles': "顯示群組成員頭銜",

--- a/lib/settings/appearance_view.dart
+++ b/lib/settings/appearance_view.dart
@@ -366,6 +366,26 @@ class DisplaySettingsView extends StatelessWidget {
                   ),
                   _toggleRow(
                     context,
+                    HeroAppIcons.pictureInPicture.data,
+                    AppStrings.t(
+                      AppStringKeys.appearanceDisableChatListSwipeActions,
+                    ),
+                    theme.disableChatListSwipeActions,
+                    (v) => theme.disableChatListSwipeActions = v,
+                  ),
+                  _toggleRow(
+                    context,
+                    HeroAppIcons.arrowsUpDown.data,
+                    AppStrings.t(
+                      AppStringKeys.appearanceChatListFolderSwipeSwitching,
+                    ),
+                    theme.chatListFolderSwipeSwitching,
+                    theme.disableChatListSwipeActions
+                        ? (v) => theme.chatListFolderSwipeSwitching = v
+                        : null,
+                  ),
+                  _toggleRow(
+                    context,
                     HeroAppIcons.palette.data,
                     AppStrings.t(AppStringKeys.appearanceShowPremiumNameColor),
                     theme.showPremiumNameColors,
@@ -444,7 +464,7 @@ class DisplaySettingsView extends StatelessWidget {
     IconData icon,
     String label,
     bool value,
-    ValueChanged<bool> onChanged,
+    ValueChanged<bool>? onChanged,
   ) =>
       const AppearanceView()._toggleRow(context, icon, label, value, onChanged);
 
@@ -790,22 +810,27 @@ extension _DisplayAppearanceHelpers on AppearanceView {
     IconData icon,
     String label,
     bool value,
-    ValueChanged<bool> onChanged,
+    ValueChanged<bool>? onChanged,
   ) {
     final c = context.colors;
+    final enabled = onChanged != null;
     return SizedBox(
       height: AppMetric.menuRowHeight + AppSpacing.xxs,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxl),
         child: Row(
           children: [
-            Icon(icon, size: AppIconSize.xl, color: AppTheme.brand),
+            Icon(
+              icon,
+              size: AppIconSize.xl,
+              color: enabled ? AppTheme.brand : c.textTertiary,
+            ),
             const SizedBox(width: AppSpacing.xl),
             Text(
               label,
               style: TextStyle(
                 fontSize: AppTextSize.bodyLarge,
-                color: c.textPrimary,
+                color: enabled ? c.textPrimary : c.textTertiary,
               ),
             ),
             const Spacer(),

--- a/lib/theme/theme_controller.dart
+++ b/lib/theme/theme_controller.dart
@@ -828,6 +828,11 @@ class ThemeController extends ChangeNotifier {
           : ChatFolderDisplayMode.hidden,
     );
     _showChatListSearch = _prefs.getBool(_chatListSearchKey) ?? true;
+    _disableChatListSwipeActions =
+        _prefs.getBool(_disableChatListSwipeActionsKey) ?? false;
+    _chatListFolderSwipeSwitching =
+        _disableChatListSwipeActions &&
+        (_prefs.getBool(_chatListFolderSwipeSwitchingKey) ?? false);
     _hideSidebarPhone = _prefs.getBool(_hideSidebarPhoneKey) ?? false;
     _showMemberTags = _prefs.getBool(_memberTagsKey) ?? false;
     _showPremiumNameColors = _prefs.getBool(_premiumNameColorsKey) ?? true;
@@ -876,6 +881,9 @@ class ThemeController extends ChangeNotifier {
   // Retained only to migrate the former show/hide toggle.
   static const _chatFolderFilterKey = 'showChatFolderFilter';
   static const _chatListSearchKey = 'showChatListSearch';
+  static const _disableChatListSwipeActionsKey = 'disableChatListSwipeActions';
+  static const _chatListFolderSwipeSwitchingKey =
+      'chatListFolderSwipeSwitching';
   static const _hideSidebarPhoneKey = 'hideSidebarPhone';
   static const _memberTagsKey = 'showMemberTags';
   static const _premiumNameColorsKey = 'showPremiumNameColors';
@@ -912,6 +920,8 @@ class ThemeController extends ChangeNotifier {
   late bool _circularGroupAvatars;
   late ChatFolderDisplayMode _chatFolderDisplayMode;
   bool _showChatListSearch = true;
+  bool _disableChatListSwipeActions = false;
+  bool _chatListFolderSwipeSwitching = false;
   bool _hideSidebarPhone = false;
   bool _showMemberTags = false;
   bool _showPremiumNameColors = true;
@@ -965,6 +975,8 @@ class ThemeController extends ChangeNotifier {
   bool get circularGroupAvatars => _circularGroupAvatars;
   ChatFolderDisplayMode get chatFolderDisplayMode => _chatFolderDisplayMode;
   bool get showChatListSearch => _showChatListSearch;
+  bool get disableChatListSwipeActions => _disableChatListSwipeActions;
+  bool get chatListFolderSwipeSwitching => _chatListFolderSwipeSwitching;
   bool get hideSidebarPhone => _hideSidebarPhone;
   bool get showMemberTags => _showMemberTags;
   bool get showPremiumNameColors => _showPremiumNameColors;
@@ -1284,6 +1296,25 @@ class ThemeController extends ChangeNotifier {
   set showChatListSearch(bool value) {
     _showChatListSearch = value;
     _prefs.setBool(_chatListSearchKey, value);
+    notifyListeners();
+  }
+
+  set disableChatListSwipeActions(bool value) {
+    if (_disableChatListSwipeActions == value) return;
+    _disableChatListSwipeActions = value;
+    _prefs.setBool(_disableChatListSwipeActionsKey, value);
+    if (!value && _chatListFolderSwipeSwitching) {
+      _chatListFolderSwipeSwitching = false;
+      _prefs.setBool(_chatListFolderSwipeSwitchingKey, false);
+    }
+    notifyListeners();
+  }
+
+  set chatListFolderSwipeSwitching(bool value) {
+    final next = value && _disableChatListSwipeActions;
+    if (_chatListFolderSwipeSwitching == next) return;
+    _chatListFolderSwipeSwitching = next;
+    _prefs.setBool(_chatListFolderSwipeSwitchingKey, next);
     notifyListeners();
   }
 


### PR DESCRIPTION
## What

Two new toggles under **Settings → Display → Chat List**:

1. **Disable chat list swipe actions** (default off)
   - When on, chat rows no longer reveal pin / mark unread / leave actions on horizontal swipe.

2. **Swipe to switch chat folders** (default off)
   - Only enabled when the first toggle is on, so the two gestures never conflict.
   - When on, a left/right swipe inside the chat list switches between chat folders.

## Why

Some users find the row swipe actions get in the way, and would rather use that gesture to move between folders. Making folder swipe depend on disabling row swipe keeps the two behaviours from colliding.

## Details

- New persisted prefs on `ThemeController`: `disableChatListSwipeActions`, `chatListFolderSwipeSwitching`.
- Chat list row swipe is gated by the first pref; folder swipe gesture is gated by the second.
- The folder-swipe toggle is visually disabled (greyed out, no tap) until row swipe actions are disabled.
- Strings translated for all supported locales (en, zh-Hans, zh-Hant, de, es, fr, ja, ko).
- `flutter analyze` clean, `flutter test` 81/81 passing.