### PR TITLE
Add proxy icon to chat list header

### DIFF
--- a/lib/chats/chat_list_view.dart
+++ b/lib/chats/chat_list_view.dart
@@ -125,6 +125,7 @@ class _ChatListViewState extends State<ChatListView> {
   bool _toggleUnreadTargetNext = true;
   bool _didApplyTopAssistantInitialOffset = false;
   bool _showProxyIcon = false;
+  int _proxyStatusRequest = 0;
   int _lastVisibleRows = 1;
 
   ScrollController _newScrollController({double initialScrollOffset = 0}) {
@@ -211,22 +212,22 @@ class _ChatListViewState extends State<ChatListView> {
   }
 
   Future<void> _loadProxyStatus() async {
+    final request = ++_proxyStatusRequest;
     try {
       final res = await TdClient.shared.query({'@type': 'getProxies'});
-      final list =
-          res.objects('proxies') ?? const <Map<String, dynamic>>[];
-      if (!mounted) return;
+      final list = res.objects('proxies') ?? const <Map<String, dynamic>>[];
+      if (!mounted || request != _proxyStatusRequest) return;
       // Show the proxy shortcut only when at least one proxy exists.
       setState(() => _showProxyIcon = list.isNotEmpty);
     } catch (_) {
-      // On any failure, keep the icon hidden.
+      // A failed refresh must not overwrite the last known proxy state.
     }
   }
 
   Future<void> _navigateToProxyView() async {
-    await Navigator.of(context).push(
-      MaterialPageRoute(builder: (_) => const ProxyView()),
-    );
+    await Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (_) => const ProxyView()));
     // Refresh in case the user added or removed a proxy.
     if (mounted) unawaited(_loadProxyStatus());
   }

--- a/lib/chats/chat_list_view.dart
+++ b/lib/chats/chat_list_view.dart
@@ -28,6 +28,7 @@ import '../contacts/add_people_view.dart';
 import '../contacts/create_group_view.dart';
 import '../profile/emoji_status_picker.dart';
 import '../settings/edit_field_view.dart';
+import '../settings/proxy_view.dart';
 import '../settings/topic_group_display_mode.dart';
 import '../tdlib/json_helpers.dart';
 import '../tdlib/td_client.dart';
@@ -122,8 +123,8 @@ class _ChatListViewState extends State<ChatListView> {
   int _lastHandledMarkAllReadRequest = 0;
   int _pendingScrollAttempts = 0;
   bool _toggleUnreadTargetNext = true;
-  bool _archiveRevealed = false;
-  double _archivePullDistance = 0;
+  bool _didApplyTopAssistantInitialOffset = false;
+  bool _showProxyIcon = false;
   int _lastVisibleRows = 1;
 
   ScrollController _newScrollController({double initialScrollOffset = 0}) {
@@ -141,6 +142,7 @@ class _ChatListViewState extends State<ChatListView> {
       if (mounted) _onControllerRequest();
     });
     _loadMe();
+    _loadProxyStatus();
     // Keep the header's name/status/photo live — TDLib emits updateUser for us
     // when the status or profile changes.
     _userSub = TdClient.shared.subscribe().listen((u) {
@@ -206,6 +208,27 @@ class _ChatListViewState extends State<ChatListView> {
         });
       }
     } catch (_) {}
+  }
+
+  Future<void> _loadProxyStatus() async {
+    try {
+      final res = await TdClient.shared.query({'@type': 'getProxies'});
+      final list =
+          res.objects('proxies') ?? const <Map<String, dynamic>>[];
+      if (!mounted) return;
+      // Show the proxy shortcut only when at least one proxy exists.
+      setState(() => _showProxyIcon = list.isNotEmpty);
+    } catch (_) {
+      // On any failure, keep the icon hidden.
+    }
+  }
+
+  Future<void> _navigateToProxyView() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const ProxyView()),
+    );
+    // Refresh in case the user added or removed a proxy.
+    if (mounted) _loadProxyStatus();
   }
 
   Future<void> _openChat(ChatSummary chat) async {
@@ -633,6 +656,20 @@ class _ChatListViewState extends State<ChatListView> {
                   child: AppIcon(
                     HeroAppIcons.folder,
                     size: AppIconSize.toolbar,
+                    color: c.textPrimary,
+                  ),
+                ),
+              ),
+            if (_showProxyIcon)
+              GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => _navigateToProxyView(),
+                child: SizedBox(
+                  width: AppMetric.hitTarget,
+                  height: AppMetric.hitTarget,
+                  child: AppIcon(
+                    HeroAppIcons.globe,
+                    size: AppIconSize.add,
                     color: c.textPrimary,
                   ),
                 ),

--- a/lib/chats/chat_list_view.dart
+++ b/lib/chats/chat_list_view.dart
@@ -228,7 +228,7 @@ class _ChatListViewState extends State<ChatListView> {
       MaterialPageRoute(builder: (_) => const ProxyView()),
     );
     // Refresh in case the user added or removed a proxy.
-    if (mounted) _loadProxyStatus();
+    if (mounted) unawaited(_loadProxyStatus());
   }
 
   Future<void> _openChat(ChatSummary chat) async {
@@ -663,7 +663,7 @@ class _ChatListViewState extends State<ChatListView> {
             if (_showProxyIcon)
               GestureDetector(
                 behavior: HitTestBehavior.opaque,
-                onTap: () => _navigateToProxyView(),
+                onTap: _navigateToProxyView,
                 child: SizedBox(
                   width: AppMetric.hitTarget,
                   height: AppMetric.hitTarget,


### PR DESCRIPTION
Implemented per user request: show proxy icon in top-right area when proxy list not empty; tapping opens proxy settings. UI follows existing style.