### PR TITLE
fix(ui): hide chat folder button when no chat folders exist

### DIFF
--- a/lib/chats/chat_list_view.dart
+++ b/lib/chats/chat_list_view.dart
@@ -607,7 +607,7 @@ class _ChatListViewState extends State<ChatListView> {
               ),
               const SizedBox(width: AppSpacing.md),
             ],
-            if (useFilterMenu)
+            if (useFilterMenu && _model.filters.isNotEmpty)
               GestureDetector(
                 behavior: HitTestBehavior.opaque,
                 onTap: () => setState(() {


### PR DESCRIPTION
Hide the chat folder button when there are no chat folders to avoid the error page.