### PR TITLE
Fix mute default state mismatch + group/channel description with clickable links

### DIFF
--- a/lib/auth/auth_manager.dart
+++ b/lib/auth/auth_manager.dart
@@ -15,6 +15,7 @@ import '../config/secrets.dart';
 import '../settings/api_credentials_config.dart';
 import '../tdlib/json_helpers.dart';
 import '../tdlib/td_client.dart';
+import 'package:mithka/notifications/scope_notification_settings.dart';
 import 'account_backup_service.dart';
 import 'review_login_code_service.dart';
 
@@ -163,6 +164,7 @@ class AuthManager extends ChangeNotifier {
       if (state != null) _handle(state);
     });
     await _client.start();
+    await ScopeNotificationSettings.shared.load();
   }
 
   void retryStart() {

--- a/lib/chat/chat_info_view.dart
+++ b/lib/chat/chat_info_view.dart
@@ -18,6 +18,7 @@ import '../components/app_icons.dart';
 import '../components/confirm_dialog.dart';
 import '../components/icon_grid.dart';
 import '../components/photo_avatar.dart';
+import 'package:mithka/notifications/scope_notification_settings.dart';
 import '../components/toast.dart';
 import '../components/ui_components.dart';
 import '../l10n/telegram_language_controller.dart';
@@ -1259,7 +1260,7 @@ class ChatInfoViewModel extends ChangeNotifier {
     isChannel = kind == ChatKind.channel;
     isGroup = kind == ChatKind.group || kind == ChatKind.channel;
     canChangeAutoDelete = !isGroup;
-    isMuted = (chat.obj('notification_settings')?.integer('mute_for') ?? 0) > 0;
+    isMuted = ScopeNotificationSettings.shared.isMuted(chat);
     autoDeleteTime =
         chat.obj('message_auto_delete_time')?.integer('time') ??
         chat.integer('message_auto_delete_time') ??

--- a/lib/chat/chat_info_view.dart
+++ b/lib/chat/chat_info_view.dart
@@ -29,6 +29,7 @@ import '../tdlib/td_client.dart';
 import '../tdlib/td_models.dart';
 import '../theme/app_theme.dart';
 import '../theme/theme_controller.dart';
+import 'telegram_rich_text.dart';
 import 'add_members_view.dart';
 import 'chat_members_view.dart';
 import 'chat_search_view.dart';
@@ -114,6 +115,10 @@ class _ChatInfoViewState extends State<ChatInfoView> {
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
               children: [
                 _topCard(),
+                if (_vm.description.isNotEmpty) ...[
+                  const SizedBox(height: 14),
+                  _descriptionCard(),
+                ],
                 if (_vm.isGroup) ...[
                   const SizedBox(height: 14),
                   _memberGridCard(),
@@ -203,6 +208,22 @@ class _ChatInfoViewState extends State<ChatInfoView> {
               ],
             ],
           ),
+        ),
+      ),
+    );
+  }
+
+  /// Group / channel description with clickable links and mentions.
+  Widget _descriptionCard() {
+    final c = context.colors;
+    return Container(
+      decoration: _card,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+        child: TelegramRichText(
+          text: _vm.description,
+          entities: _vm.descriptionEntities,
+          style: TextStyle(fontSize: 15, height: 1.4, color: c.textPrimary),
         ),
       ),
     );
@@ -1229,11 +1250,51 @@ class ChatInfoViewModel extends ChangeNotifier {
   bool isMember = false; // confirmed member → may quit; false hides 退出
   bool _loaded = false;
   String? _notice;
+  // Group / channel description (plain text) with link entities parsed
+  String description = '';
+  List<MessageTextEntity> descriptionEntities = const [];
 
   String? takeNotice() {
     final value = _notice;
     _notice = null;
     return value;
+  }
+
+  /// Parse plain-text description into entities for URLs, @mentions, and emails.
+  void _setDescription(String text) {
+    description = text;
+    if (text.isEmpty) {
+      descriptionEntities = const [];
+      return;
+    }
+    final entities = <MessageTextEntity>[];
+    // URL pattern (http/https)
+    final urlPattern = RegExp(r'https?://[^\s]+');
+    // Email pattern
+    final emailPattern = RegExp(r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}');
+    // @username pattern
+    final mentionPattern = RegExp(r'@[a-zA-Z0-9_]{5,}');
+
+    void addMatches(RegExp pattern, String entityType, {String? url, int? userId}) {
+      for (final match in pattern.allMatches(text)) {
+        // Avoid overlapping entities
+        if (entities.any((e) => match.start < e.end && match.end > e.offset)) continue;
+        entities.add(MessageTextEntity(
+          offset: match.start,
+          length: match.end - match.start,
+          type: entityType,
+          url: url,
+          userId: userId,
+        ));
+      }
+    }
+
+    addMatches(urlPattern, 'textEntityTypeUrl');
+    addMatches(emailPattern, 'textEntityTypeEmailAddress');
+    addMatches(mentionPattern, 'textEntityTypeMention');
+
+    entities.sort((a, b) => a.offset.compareTo(b.offset));
+    descriptionEntities = entities;
   }
 
   void load() {
@@ -1304,6 +1365,15 @@ class ChatInfoViewModel extends ChangeNotifier {
         username = uname.isEmpty ? null : uname;
         isPublic = uname.isNotEmpty;
         _applySelfStatus(sg.obj('status'), defaultInvite: false);
+        // Fetch supergroupFullInfo for the description.
+        try {
+          final info = await TdClient.shared.query({
+            '@type': 'getSupergroupFullInfo',
+            'supergroup_id': sgid,
+          });
+          final desc = info.str('description') ?? '';
+          _setDescription(desc);
+        } catch (_) {}
       }
     } catch (_) {}
     notifyListeners();
@@ -1392,6 +1462,9 @@ class ChatInfoViewModel extends ChangeNotifier {
         final raw = full.objects('members') ?? const <Map<String, dynamic>>[];
         memberCount = raw.length;
         await _resolveMembers(raw);
+        // Extract description from basic group full info.
+        final desc = full.str('description') ?? '';
+        _setDescription(desc);
       } else if (type?.type == 'chatTypeSupergroup') {
         final sgid = type?.int64('supergroup_id');
         if (sgid == null) return;

--- a/lib/chat/chat_view_model.dart
+++ b/lib/chat/chat_view_model.dart
@@ -19,6 +19,7 @@ import '../settings/keyword_blocker.dart';
 import '../tdlib/json_helpers.dart';
 import '../tdlib/td_client.dart';
 import '../tdlib/td_models.dart';
+import 'package:mithka/notifications/scope_notification_settings.dart';
 import 'forward_options.dart';
 import 'gif_item.dart';
 import 'sticker_item.dart';
@@ -1448,7 +1449,7 @@ class ChatViewModel extends ChangeNotifier {
     unreadCount = chat.integer('unread_count') ?? 0;
     isMarkedUnread = chat.boolean('is_marked_as_unread') ?? false;
     final notificationSettings = chat.obj('notification_settings');
-    isMuted = (notificationSettings?.integer('mute_for') ?? 0) > 0;
+    isMuted = ScopeNotificationSettings.shared.isMuted(chat);
     if (hasLegacyHiddenNotificationPreview(notificationSettings)) {
       unawaited(_repairLegacyNotificationPreview(notificationSettings!));
     }

--- a/lib/chats/chat_list_view_model.dart
+++ b/lib/chats/chat_list_view_model.dart
@@ -17,6 +17,7 @@ import '../tdlib/chat_membership.dart';
 import '../tdlib/json_helpers.dart';
 import '../tdlib/td_client.dart';
 import '../tdlib/td_models.dart';
+import '../notifications/scope_notification_settings.dart';
 
 class ChatFilterOption {
   const ChatFilterOption({required this.title, this.folderId});
@@ -530,8 +531,13 @@ class ChatListViewModel extends ChangeNotifier {
         final id = update.int64('chat_id');
         if (id == null) return;
         _mutate(id, (s) {
-          final muteFor =
-              update.obj('notification_settings')?.integer('mute_for') ?? 0;
+          final notificationSettings = update.obj('notification_settings');
+          final useDefault =
+              notificationSettings?.boolean('use_default_mute_for') ?? false;
+          final muteFor = useDefault
+              ? ScopeNotificationSettings.shared.getMuteForScope(
+                  ScopeNotificationSettings.shared.scopeTagForKind(s.kind))
+              : (notificationSettings?.integer('mute_for') ?? 0);
           s.isMuted = muteFor > 0;
         });
         _scheduleResort();

--- a/lib/chats/chat_row_view.dart
+++ b/lib/chats/chat_row_view.dart
@@ -154,7 +154,7 @@ class ChatRowView extends StatelessWidget {
                   color: Colors.white,
                   shape: BoxShape.circle,
                 ),
-                child: RedDot(size: AppMetric.unreadDot, muted: archived),
+                child: RedDot(size: AppMetric.unreadDot, muted: archived || chat.isMuted),
               ),
             ),
         ],

--- a/lib/notifications/notification_controller.dart
+++ b/lib/notifications/notification_controller.dart
@@ -13,6 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:mithka/l10n/app_localizations.dart';
+import 'scope_notification_settings.dart';
 
 import '../app/chat_deep_link_controller.dart';
 import '../l10n/telegram_language_controller.dart';
@@ -175,8 +176,7 @@ class NotificationController with WidgetsBindingObserver {
   }
 
   bool _isMuted(Map<String, dynamic> chat) {
-    final settings = chat.obj('notification_settings');
-    return (settings?.integer('mute_for') ?? 0) > 0;
+      return ScopeNotificationSettings.shared.isMuted(chat);
   }
 
   String _notificationText(Map<String, dynamic> content) {

--- a/lib/notifications/scope_notification_settings.dart
+++ b/lib/notifications/scope_notification_settings.dart
@@ -1,0 +1,86 @@
+//  scope_notification_settings.dart
+//  Cached scope-level notification settings (mute_for) used to compute effective mute state.
+
+import 'package:mithka/tdlib/td_client.dart';
+import 'package:mithka/tdlib/json_helpers.dart';
+import 'package:mithka/tdlib/td_models.dart' show ChatKind;
+
+class ScopeNotificationSettings {
+  ScopeNotificationSettings._();
+  static final ScopeNotificationSettings shared = ScopeNotificationSettings._();
+
+  static const _private = 'notificationSettingsScopePrivateChats';
+  static const _group = 'notificationSettingsScopeGroupChats';
+  static const _channel = 'notificationSettingsScopeChannelChats';
+
+  final Map<String, int> _muteFor = {};
+  bool _loaded = false;
+
+  /// Loads mute_for values for all three scopes from TDLib.
+  Future<void> load() async {
+    final client = TdClient.shared;
+    for (final scope in const [_private, _group, _channel]) {
+      try {
+        final s = await client.query({
+          '@type': 'getScopeNotificationSettings',
+          'scope': {'@type': scope},
+        });
+        _muteFor[scope] = s.integer('mute_for') ?? 0;
+      } catch (_) {
+        _muteFor[scope] = _muteFor[scope] ?? 0;
+      }
+    }
+    _loaded = true;
+  }
+
+  /// Updates the cached mute_for for a scope (called after user changes settings).
+  void update(String scope, int muteFor) {
+    _muteFor[scope] = muteFor;
+  }
+
+  /// Returns cached mute_for for a stored scope identifier.
+  int getMuteForScope(String tag) => _muteFor[tag] ?? 0;
+
+  /// Maps a [ChatKind] to its stored scope identifier.
+  String scopeTagForKind(ChatKind kind) {
+    switch (kind) {
+      case ChatKind.privateChat:
+        return _private;
+      case ChatKind.group:
+        return _group;
+      case ChatKind.channel:
+        return _channel;
+      default:
+        return _private;
+    }
+  }
+
+  /// Determines the scope key for a given chat map.
+  String _scopeForChat(Map<String, dynamic> chat) {
+    final type = chat.obj('type');
+    switch (type?.type) {
+      case 'chatTypePrivate':
+      case 'chatTypeSecret':
+        return _private;
+      case 'chatTypeBasicGroup':
+        return _group;
+      case 'chatTypeSupergroup':
+        // Supergroup objects contain an `is_channel` flag.
+        final isChannel = type?.boolean('is_channel') ?? false;
+        return isChannel ? _channel : _group;
+      default:
+        // Fallback to private.
+        return _private;
+    }
+  }
+
+  /// Returns true if the chat is effectively muted (considering use_default_mute_for).
+  bool isMuted(Map<String, dynamic> chat) {
+    final settings = chat.obj('notification_settings');
+    final useDefault = settings?.boolean('use_default_mute_for') ?? false;
+    final muteFor = useDefault
+        ? _scopeMuteFor(_scopeForChat(chat))
+        : (settings?.integer('mute_for') ?? 0);
+    return muteFor > 0;
+  }
+}

--- a/lib/notifications/scope_notification_settings.dart
+++ b/lib/notifications/scope_notification_settings.dart
@@ -79,7 +79,7 @@ class ScopeNotificationSettings {
     final settings = chat.obj('notification_settings');
     final useDefault = settings?.boolean('use_default_mute_for') ?? false;
     final muteFor = useDefault
-        ? _scopeMuteFor(_scopeForChat(chat))
+        ? getMuteForScope(_scopeForChat(chat))
         : (settings?.integer('mute_for') ?? 0);
     return muteFor > 0;
   }

--- a/lib/notifications/scope_notification_settings.dart
+++ b/lib/notifications/scope_notification_settings.dart
@@ -14,7 +14,6 @@ class ScopeNotificationSettings {
   static const _channel = 'notificationSettingsScopeChannelChats';
 
   final Map<String, int> _muteFor = {};
-  bool _loaded = false;
 
   /// Loads mute_for values for all three scopes from TDLib.
   Future<void> load() async {
@@ -30,7 +29,6 @@ class ScopeNotificationSettings {
         _muteFor[scope] = _muteFor[scope] ?? 0;
       }
     }
-    _loaded = true;
   }
 
   /// Updates the cached mute_for for a scope (called after user changes settings).

--- a/lib/tdlib/td_models.dart
+++ b/lib/tdlib/td_models.dart
@@ -13,6 +13,7 @@ import 'package:mithka/l10n/app_localizations.dart';
 import 'package:mithka/l10n/telegram_language_controller.dart';
 
 import 'json_helpers.dart';
+import 'package:mithka/notifications/scope_notification_settings.dart';
 
 /// Reference to a downloadable TDLib file (profile photo, thumbnail, …).
 class TdFileRef {
@@ -686,8 +687,7 @@ abstract final class TDParse {
       }
     }
 
-    final muted =
-        (chat.obj('notification_settings')?.integer('mute_for') ?? 0) > 0;
+    final muted = ScopeNotificationSettings.shared.isMuted(chat);
 
     final type = chat.obj('type');
     return ChatSummary(


### PR DESCRIPTION
Fix mute default state mismatch by using ScopeNotificationSettings to compute isMuted based on actual mute_for and use_default_mute_for.