### PR TITLE
fix: update bot inline keyboard buttons on updateMessageEdited

### DIFF
--- a/lib/chat/chat_view_model.dart
+++ b/lib/chat/chat_view_model.dart
@@ -2254,14 +2254,6 @@ class ChatViewModel extends ChangeNotifier {
           updateLinkPreview: true,
         );
 
-      case 'updateMessageReplyMarkup':
-        if (update.int64('chat_id') != chatId) return;
-        final messageId = update.int64('message_id');
-        if (messageId == null) return;
-        _replaceButtonRows(
-          messageId,
-          TDParse.messageButtonRows(update.obj('reply_markup')),
-        );
 
       case 'updateChat':
         final chat = update.obj('chat');
@@ -2400,6 +2392,9 @@ class ChatViewModel extends ChangeNotifier {
       case 'updateMessageEdited':
         if (update.int64('chat_id') != chatId) return;
         final mid = update.int64('message_id');
+        if (mid == null) return;
+        final replyMarkup = update.obj('reply_markup');
+        _replaceButtonRows(mid, TDParse.messageButtonRows(replyMarkup));
         final i = messages.indexWhere((m) => m.id == mid);
         if (i >= 0) {
           messages[i].isEdited = true;


### PR DESCRIPTION
## Problem

When a Telegram bot edits a message's inline keyboard (reply markup), Mithka doesn't update the displayed buttons. Tapping the old buttons results in an error because the callback data is no longer valid.

## Root Cause

1. **Dead code path**: The `updateMessageReplyMarkup` case in `ChatViewModel._handle()` tried to handle button updates from a non-existent TDLib update type. TDLib doesn't have an `updateMessageReplyMarkup` update — the actual update types are `updateMessageEdited` (for message-level inline keyboards) and `updateChatReplyMarkup` (for chat-level reply markups).

2. **Missing reply_markup handling**: The `updateMessageEdited` handler only set `isEdited = true` on the message, completely ignoring the `reply_markup` field in the update. When a bot edits a message's inline keyboard, TDLib sends `updateMessageEdited` with the new `reply_markup`, but it was never processed.

## Fix

- Added `reply_markup` handling to the `updateMessageEdited` handler — calls `_replaceButtonRows()` to update the message's button rows when a message edit includes a new reply markup.
- Added null guard for `message_id` before using it.
- Removed the dead `updateMessageReplyMarkup` handler that was referencing a non-existent TDLib update type.

## Changes

- `lib/chat/chat_view_model.dart`: 3 lines added, 8 lines removed