### PR TITLE
Show 收藏夹 (Saved Messages) with bookmark icon for self chat in chat list

### DIFF
--- a/lib/chats/chat_list_view_model.dart
+++ b/lib/chats/chat_list_view_model.dart
@@ -63,6 +63,7 @@ class ChatListViewModel extends ChangeNotifier {
   StreamSubscription? _sub;
   bool _listening = false;
   bool _prefetchingMain = false;
+  int? _selfUserId;
   final Set<String> _loadingChatLists = {};
   final Set<String> _exhaustedChatLists = {};
   static const _pageSize = 100;
@@ -77,6 +78,7 @@ class ChatListViewModel extends ChangeNotifier {
     _loadFilters();
     _loadChats(_initialPageSize);
     _deferWarmCaches();
+    _resolveSelfUserId();
   }
 
   @override
@@ -229,6 +231,13 @@ class ChatListViewModel extends ChangeNotifier {
       if (!_listening) return;
       if (_selectedFilter.isAll) _prefetchMainChats();
     });
+  }
+
+  Future<void> _resolveSelfUserId() async {
+    try {
+      final me = await _client.query({'@type': 'getMe'});
+      _selfUserId = me.int64('id');
+    } catch (_) {}
   }
 
   void _prefetchMainChats() {
@@ -745,16 +754,19 @@ class ChatListViewModel extends ChangeNotifier {
         user.obj('emoji_status')?.obj('type')?.int64('custom_emoji_id') ??
         user.obj('emoji_status')?.int64('custom_emoji_id') ??
         0;
+    final isSelf = (userId == _selfUserId);
     for (final chat in _map.values) {
       if (chat.peerUserId != userId) continue;
       if (chat.peerIsPremium == isPremium &&
           chat.peerAccentColorId == accent &&
-          chat.peerEmojiStatusId == status) {
+          chat.peerEmojiStatusId == status &&
+          chat.isSelfChat == isSelf) {
         continue;
       }
       chat.peerIsPremium = isPremium;
       chat.peerAccentColorId = accent;
       chat.peerEmojiStatusId = status;
+      chat.isSelfChat = isSelf;
       changed = true;
     }
     if (changed) notifyListeners();

--- a/lib/chats/chat_row_view.dart
+++ b/lib/chats/chat_row_view.dart
@@ -13,6 +13,7 @@ import '../chat/custom_emoji.dart';
 import '../components/app_icons.dart';
 import '../components/photo_avatar.dart';
 import '../components/ui_components.dart';
+import '../l10n/app_localizations.dart';
 import '../tdlib/td_models.dart';
 import '../theme/app_theme.dart';
 import '../theme/date_text.dart';
@@ -72,7 +73,9 @@ class ChatRowView extends StatelessWidget {
                   children: [
                     Flexible(
                       child: Text(
-                        chat.title,
+                        chat.isSelfChat
+                            ? AppStringKeys.chatSavedMessages.l10n(context)
+                            : chat.title,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: TextStyle(
@@ -122,18 +125,37 @@ class ChatRowView extends StatelessWidget {
     final theme = context.watch<ThemeController>();
     final circleGroups = theme.circularGroupAvatars;
     final avatarSize = theme.avatarSize;
+    final c = context.colors;
     return SizedBox(
       width: avatarSize,
       height: avatarSize,
       child: Stack(
         clipBehavior: Clip.none,
         children: [
-          PhotoAvatar(
-            title: chat.title,
-            photo: chat.photo,
-            size: avatarSize,
-            square: chat.usesSquareAvatar && !circleGroups,
-          ),
+          if (chat.isSelfChat)
+            Container(
+              width: avatarSize,
+              height: avatarSize,
+              decoration: BoxDecoration(
+                color: c.saveIconBg,
+                borderRadius: circleGroups
+                    ? BorderRadius.circular(avatarSize / 2)
+                    : BorderRadius.circular(AppSpacing.md),
+              ),
+              alignment: Alignment.center,
+              child: AppIcon(
+                HeroAppIcons.solidBookmark,
+                size: avatarSize * 0.48,
+                color: c.saveIconFg,
+              ),
+            )
+          else
+            PhotoAvatar(
+              title: chat.title,
+              photo: chat.photo,
+              size: avatarSize,
+              square: chat.usesSquareAvatar && !circleGroups,
+            ),
           if (chat.unreadCount > 0)
             Positioned(
               right: 0,

--- a/lib/components/app_icons.dart
+++ b/lib/components/app_icons.dart
@@ -120,6 +120,7 @@ class HeroAppIcons {
   static const share = AppIconData(HeroiconsOutline.share);
   static const shieldHalved = AppIconData(HeroiconsOutline.shieldCheck);
   static const solidBell = AppIconData(HeroiconsSolid.bell);
+  static const solidBookmark = AppIconData(HeroiconsSolid.bookmark);
   static const solidCircle = AppIconData(HeroiconsSolid.stopCircle);
   static const solidCircleUser = AppIconData(HeroiconsSolid.userCircle);
   static const solidCircleXmark = AppIconData(HeroiconsSolid.xCircle);

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -489,6 +489,7 @@ abstract final class AppStringKeys {
       'chatRestrictedTelegramTosMessage';
   static const chatRestrictedTitle = 'chatRestrictedTitle';
   static const chatSavedToSavedMessages = 'chatSavedToSavedMessages';
+  static const chatSavedMessages = 'chatSavedMessages';
   static const chatSaveFailed = 'chatSaveFailed';
   static const chatSearchHistoryTitle = 'chatSearchHistoryTitle';
   static const chatSearchMessagePlaceholder = 'chatSearchMessagePlaceholder';

--- a/lib/l10n/messages/de.dart
+++ b/lib/l10n/messages/de.dart
@@ -343,6 +343,7 @@ const deMessages = <String, String>{
       "Diese Gruppe kann nicht angezeigt werden, weil sie gegen die Nutzungsbedingungen von Telegram verstoßen hat. Du kannst zur Chatliste zurückkehren oder die Gruppe verlassen.",
   'chatRestrictedTitle': "Sicherheitshinweis",
   'chatSavedToSavedMessages': "In Saved Messages gespeichert",
+  'chatSavedMessages': "Gespeicherte Nachrichten",
   'chatSaveFailed': "Speichern fehlgeschlagen: {value1}",
   'chatSearchHistoryTitle': "Chatverlauf durchsuchen",
   'chatSearchMessagePlaceholder': "Nachrichten in diesem Chat suchen",

--- a/lib/l10n/messages/en.dart
+++ b/lib/l10n/messages/en.dart
@@ -337,6 +337,7 @@ const enMessages = <String, String>{
       "This group can’t be displayed because it violated Telegram's Terms of Service. You can go back or leave the group.",
   'chatRestrictedTitle': "Safety notice",
   'chatSavedToSavedMessages': "Saved to Saved Messages",
+  'chatSavedMessages': "Saved Messages",
   'chatSaveFailed': "Save failed: {value1}",
   'chatSearchHistoryTitle': "Search chat history",
   'chatSearchMessagePlaceholder': "Search messages in this chat",

--- a/lib/l10n/messages/es.dart
+++ b/lib/l10n/messages/es.dart
@@ -338,6 +338,7 @@ const esMessages = <String, String>{
       "Este grupo no se puede mostrar porque infringió las Condiciones de servicio de Telegram. Puedes volver a la lista de chats o salir del grupo.",
   'chatRestrictedTitle': "Aviso de seguridad",
   'chatSavedToSavedMessages': "Guardado en Saved Messages",
+  'chatSavedMessages': "Mensajes guardados",
   'chatSaveFailed': "No se pudo guardar: {value1}",
   'chatSearchHistoryTitle': "Buscar en el historial del chat",
   'chatSearchMessagePlaceholder': "Buscar mensajes en este chat",

--- a/lib/l10n/messages/fr.dart
+++ b/lib/l10n/messages/fr.dart
@@ -345,6 +345,7 @@ const frMessages = <String, String>{
       "Ce groupe ne peut pas être affiché, car il a enfreint les conditions d’utilisation de Telegram. Vous pouvez revenir à la liste des discussions ou quitter le groupe.",
   'chatRestrictedTitle': "Avertissement de sécurité",
   'chatSavedToSavedMessages': "Enregistré dans Saved Messages",
+  'chatSavedMessages': "Messages enregistrés",
   'chatSaveFailed': "Échec de l’enregistrement : {value1}",
   'chatSearchHistoryTitle': "Rechercher dans l’historique",
   'chatSearchMessagePlaceholder':

--- a/lib/l10n/messages/ja.dart
+++ b/lib/l10n/messages/ja.dart
@@ -323,6 +323,7 @@ const jaMessages = <String, String>{
       "このグループは Telegram の利用規約に違反したため表示できません。チャット一覧へ戻るか、グループを退出できます。",
   'chatRestrictedTitle': "安全に関するお知らせ",
   'chatSavedToSavedMessages': "Saved Messages に保存しました",
+  'chatSavedMessages': "保存済みメッセージ",
   'chatSaveFailed': "保存に失敗しました：{value1}",
   'chatSearchHistoryTitle': "チャット履歴を検索",
   'chatSearchMessagePlaceholder': "このチャットのメッセージを検索",

--- a/lib/l10n/messages/ko.dart
+++ b/lib/l10n/messages/ko.dart
@@ -323,6 +323,7 @@ const koMessages = <String, String>{
       "이 그룹은 Telegram 서비스 약관을 위반하여 표시할 수 없습니다. 채팅 목록으로 돌아가거나 그룹을 나갈 수 있습니다.",
   'chatRestrictedTitle': "안전 안내",
   'chatSavedToSavedMessages': "Saved Messages에 저장됨",
+  'chatSavedMessages': "저장된 메시지",
   'chatSaveFailed': "저장 실패: {value1}",
   'chatSearchHistoryTitle': "채팅 기록 검색",
   'chatSearchMessagePlaceholder': "이 채팅의 메시지 검색",

--- a/lib/l10n/messages/zh_hans.dart
+++ b/lib/l10n/messages/zh_hans.dart
@@ -317,6 +317,7 @@ const zhHansMessages = <String, String>{
       "该群因违反 Telegram 服务条款，无法显示内容。你可以返回聊天列表，或退出该群聊。",
   'chatRestrictedTitle': "安全提示",
   'chatSavedToSavedMessages': "已保存到 Saved Messages",
+  'chatSavedMessages': "收藏夹",
   'chatSaveFailed': "保存失败：{value1}",
   'chatSearchHistoryTitle': "搜索聊天记录",
   'chatSearchMessagePlaceholder': "搜索本聊天的消息",

--- a/lib/l10n/messages/zh_hant.dart
+++ b/lib/l10n/messages/zh_hant.dart
@@ -317,6 +317,7 @@ const zhHantMessages = <String, String>{
       "該群因違反 Telegram 服務條款，無法顯示內容。你可以返回聊天列表，或退出該群聊。",
   'chatRestrictedTitle': "安全提示",
   'chatSavedToSavedMessages': "已儲存到 Saved Messages",
+  'chatSavedMessages': "收藏夾",
   'chatSaveFailed': "儲存失敗：{value1}",
   'chatSearchHistoryTitle': "搜尋聊天記錄",
   'chatSearchMessagePlaceholder': "搜尋此聊天的訊息",

--- a/lib/tdlib/td_models.dart
+++ b/lib/tdlib/td_models.dart
@@ -281,6 +281,7 @@ class ChatSummary {
     this.peerAccentColorId = -1,
     this.peerEmojiStatusId = 0,
     this.isForum = false,
+    this.isSelfChat = false,
     this.lastChatMessage,
   });
 
@@ -305,6 +306,7 @@ class ChatSummary {
   int peerAccentColorId;
   int peerEmojiStatusId;
   bool isForum;
+  bool isSelfChat;
   ChatMessage? lastChatMessage;
 
   /// Groups & channels use a rounded-square avatar unless UI preferences

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -272,6 +272,8 @@ class AppColors extends ThemeExtension<AppColors> {
     required this.textTertiary,
     required this.divider,
     required this.linkBlue,
+    required this.saveIconBg,
+    required this.saveIconFg,
   });
 
   final Color background; // list row background
@@ -291,6 +293,8 @@ class AppColors extends ThemeExtension<AppColors> {
   final Color textTertiary;
   final Color divider;
   final Color linkBlue;
+  final Color saveIconBg;
+  final Color saveIconFg;
 
   static final AppColors light = AppColors(
     background: _hex(0xFFFFFF),
@@ -310,6 +314,8 @@ class AppColors extends ThemeExtension<AppColors> {
     textTertiary: _hex(0xB0B3B8),
     divider: _hex(0xECECEC),
     linkBlue: _hex(0x4B8DEE),
+    saveIconBg: _hex(0xFFF4DF),
+    saveIconFg: _hex(0xE59900),
   );
 
   static final AppColors dark = AppColors(
@@ -330,6 +336,8 @@ class AppColors extends ThemeExtension<AppColors> {
     textTertiary: _hex(0x707276),
     divider: _hex(0x303234),
     linkBlue: _hex(0x5EA0FF),
+    saveIconBg: _hex(0x3D2E00),
+    saveIconFg: _hex(0xF0B800),
   );
 
   @override
@@ -351,6 +359,8 @@ class AppColors extends ThemeExtension<AppColors> {
     Color? textTertiary,
     Color? divider,
     Color? linkBlue,
+    Color? saveIconBg,
+    Color? saveIconFg,
   }) {
     return AppColors(
       background: background ?? this.background,
@@ -370,6 +380,8 @@ class AppColors extends ThemeExtension<AppColors> {
       textTertiary: textTertiary ?? this.textTertiary,
       divider: divider ?? this.divider,
       linkBlue: linkBlue ?? this.linkBlue,
+      saveIconBg: saveIconBg ?? this.saveIconBg,
+      saveIconFg: saveIconFg ?? this.saveIconFg,
     );
   }
 
@@ -406,6 +418,8 @@ class AppColors extends ThemeExtension<AppColors> {
       textTertiary: Color.lerp(textTertiary, other.textTertiary, t)!,
       divider: Color.lerp(divider, other.divider, t)!,
       linkBlue: Color.lerp(linkBlue, other.linkBlue, t)!,
+      saveIconBg: Color.lerp(saveIconBg, other.saveIconBg, t)!,
+      saveIconFg: Color.lerp(saveIconFg, other.saveIconFg, t)!,
     );
   }
 }


### PR DESCRIPTION
## Summary

The self chat (Saved Messages) in TDLib is a private chat where the peer user is the current user. Previously, the chat list showed the user's own avatar and name for this chat, which is inconsistent with how most Telegram clients display it.

This PR introduces the following changes:

- **Detect self chat**: Added `isSelfChat` flag to `ChatSummary`, set when the peer user ID matches the current user's ID during peer resolution in `ChatListViewModel`.
- **Display override**: In `ChatRowView`, when `isSelfChat` is true, the title shows the localized "收藏夹" (Saved Messages) string, and the avatar shows a solid bookmark icon on a themed background instead of the user's photo.
- **Icon & theming**: Added a solid bookmark icon and `saveIconBg`/`saveIconFg` theme colors for a warm amber tone that fits the app's design style.
- **Localization**: Added `chatSavedMessages` key with translations for all 8 supported languages.

## Visual change

| Before | After |
|--------|-------|
| User's own avatar + name | Bookmark icon + "收藏夹" |