### PR TITLE
Fix file download progress getting stuck after chunked download timeouts

### DIFF
--- a/lib/tdlib/td_image_loader.dart
+++ b/lib/tdlib/td_image_loader.dart
@@ -310,7 +310,7 @@ class TdFileCenter {
       } catch (_) {}
       return null;
     }
-    return downloadPriorityRange(
+    final rangeResult = await downloadPriorityRange(
       fileId,
       offset: 0,
       length: total,
@@ -319,6 +319,27 @@ class TdFileCenter {
       chunkSize: chunkSize,
       timeout: const Duration(seconds: 90),
     );
+    if (rangeResult != null) return rangeResult;
+
+    // One or more chunks timed out or failed. Fall back to a standard
+    // async download so TDLib keeps the file alive in the background and
+    // continues emitting updateFile events. Without this, the progress bar
+    // stalls at whatever fraction the chunked download reached, and the
+    // file never completes.
+    try {
+      final response = await _client.query({
+        '@type': 'downloadFile',
+        'file_id': fileId,
+        'priority': priority,
+        'offset': 0,
+        'limit': 0,
+        'synchronous': false,
+      });
+      _ingest(response);
+      return response;
+    } catch (_) {
+      return null;
+    }
   }
 
   void cancelDownload(int fileId) {


### PR DESCRIPTION
## Problem

When downloading large files in FileDetailView, the progress bar shows some progress then stops updating permanently — appearing stuck to the user.

## Root Cause

`downloadPriorityFile` splits large files into parallel synchronous chunks via `downloadPriorityRange`. Each chunk uses `synchronous: true` with a 90-second timeout.

When any chunk times out (common on slow connections, large files, or spotty networks), it is silently caught and skipped. The worker moves to the next chunk, but the timed-out chunk is never retried. If not all chunks complete:

1. `downloadPriorityRange` returns `null`
2. `downloadPriorityFile` returns `null`  
3. `FileDetailView._start` never calls `_apply` with a completion response
4. TDLib may not emit `updateFile` events for synchronous chunk requests, so the streaming progress listener never updates after workers exit
5. The progress bar freezes at whatever fraction the workers reached

## Fix

When `downloadPriorityRange` returns null (partial failure), fall back to a standard async `downloadFile` with `synchronous: false` and `limit: 0`. This tells TDLib to continue the download asynchronously in the background. `updateFile` events resume flowing to listeners, the progress bar keeps updating, and the file eventually completes.