### PR TITLE
feat: add toggle to display own chat header as '收藏夹'

### DIFF
--- a/lib/chats/chat_list_view.dart
+++ b/lib/chats/chat_list_view.dart
@@ -514,11 +514,27 @@ class _ChatListViewState extends State<ChatListView> {
           children: [
             GestureDetector(
               onTap: () => context.read<dc.DrawerController>().open(),
-              child: PhotoAvatar(
-                title: _meName,
-                photo: _mePhoto,
-                size: AppMetric.headerAvatarSize,
-              ),
+              child: context.watch<ThemeController>().displayOwnChatAsFavorites
+                  ? Container(
+                      width: AppMetric.headerAvatarSize,
+                      height: AppMetric.headerAvatarSize,
+                      decoration: BoxDecoration(
+                        color: context.colors.linkBlue,
+                        borderRadius: BorderRadius.circular(
+                          AppMetric.headerAvatarSize / 2,
+                        ),
+                      ),
+                      child: AppIcon(
+                        HeroAppIcons.thumbtack,
+                        size: AppMetric.headerAvatarSize * 0.5,
+                        color: const Color(0xFFFFFFFF),
+                      ),
+                    )
+                  : PhotoAvatar(
+                      title: _meName,
+                      photo: _mePhoto,
+                      size: AppMetric.headerAvatarSize,
+                    ),
             ),
             const SizedBox(width: AppSpacing.lg),
             Expanded(
@@ -531,7 +547,11 @@ class _ChatListViewState extends State<ChatListView> {
                     children: [
                       Flexible(
                         child: Text(
-                          _meName,
+                          context
+                                  .watch<ThemeController>()
+                                  .displayOwnChatAsFavorites
+                              ? '收藏夹'
+                              : _meName,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           style: TextStyle(
@@ -541,7 +561,10 @@ class _ChatListViewState extends State<ChatListView> {
                           ),
                         ),
                       ),
-                      if (_meStatusId != 0) ...[
+                      if (_meStatusId != 0 &&
+                          !context
+                              .watch<ThemeController>()
+                              .displayOwnChatAsFavorites) ...[
                         const SizedBox(width: AppSpacing.xs + 1),
                         GestureDetector(
                           behavior: HitTestBehavior.opaque,
@@ -556,7 +579,11 @@ class _ChatListViewState extends State<ChatListView> {
                           ),
                         ),
                       ],
-                      if (_meIsPremium && _meStatusId != 0) ...[
+                      if (_meIsPremium &&
+                          _meStatusId != 0 &&
+                          !context
+                              .watch<ThemeController>()
+                              .displayOwnChatAsFavorites) ...[
                         const SizedBox(width: AppSpacing.xs),
                         AppIcon(
                           HeroAppIcons.chevronDown,
@@ -566,27 +593,31 @@ class _ChatListViewState extends State<ChatListView> {
                       ],
                     ],
                   ),
-                  const SizedBox(height: AppSpacing.xxs),
-                  Row(
-                    children: [
-                      Container(
-                        width: AppMetric.onlineDot,
-                        height: AppMetric.onlineDot,
-                        decoration: BoxDecoration(
-                          color: AppTheme.onlineDot,
-                          shape: BoxShape.circle,
+                  if (!context
+                      .watch<ThemeController>()
+                      .displayOwnChatAsFavorites) ...[
+                    const SizedBox(height: AppSpacing.xxs),
+                    Row(
+                      children: [
+                        Container(
+                          width: AppMetric.onlineDot,
+                          height: AppMetric.onlineDot,
+                          decoration: BoxDecoration(
+                            color: AppTheme.onlineDot,
+                            shape: BoxShape.circle,
+                          ),
                         ),
-                      ),
-                      const SizedBox(width: AppSpacing.xs),
-                      Text(
-                        AppStringKeys.chatOnline.l10n(context),
-                        style: TextStyle(
-                          fontSize: AppTextSize.caption,
-                          color: c.textSecondary,
+                        const SizedBox(width: AppSpacing.xs),
+                        Text(
+                          AppStringKeys.chatOnline.l10n(context),
+                          style: TextStyle(
+                            fontSize: AppTextSize.caption,
+                            color: c.textSecondary,
+                          ),
                         ),
-                      ),
-                    ],
-                  ),
+                      ],
+                    ),
+                  ],
                 ],
               ),
             ),

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -264,6 +264,8 @@ abstract final class AppStringKeys {
   static const appearanceShowChatListSearch = 'appearanceShowChatListSearch';
   static const appearanceDisableChatListSwipeActions =
       'appearanceDisableChatListSwipeActions';
+  static const appearanceDisplayOwnChatAsFavorites =
+      'appearanceDisplayOwnChatAsFavorites';
   static const appearanceChatListFolderSwipeSwitching =
       'appearanceChatListFolderSwipeSwitching';
   static const appearanceShowEditAndReadMarks =

--- a/lib/l10n/messages/de.dart
+++ b/lib/l10n/messages/de.dart
@@ -127,6 +127,7 @@ const deMessages = <String, String>{
   'appearanceRoundGroupAvatars': "Gruppenavatare rund anzeigen",
   'appearanceSearchFont': "Schriftart suchen",
   'appearanceDisableChatListSwipeActions': 'Chatlisten-Wischaktionen deaktivieren',
+  'appearanceDisplayOwnChatAsFavorites': 'Als gespeicherte Nachrichten im Chat anzeigen',
   'appearanceChatListFolderSwipeSwitching': 'Wischen zum Wechseln der Chatordner',
   'appearanceShowChatListSearch': "Chatlistensuche anzeigen",
   'appearanceShowEditAndReadMarks':

--- a/lib/l10n/messages/en.dart
+++ b/lib/l10n/messages/en.dart
@@ -124,6 +124,7 @@ const enMessages = <String, String>{
   'appearanceRoundGroupAvatars': "Show Group Avatars as Circles",
   'appearanceSearchFont': "Search fonts",
   'appearanceDisableChatListSwipeActions': 'Disable Chat List Swipe Actions',
+  'appearanceDisplayOwnChatAsFavorites': 'Show as Saved Messages in Chat List',
   'appearanceChatListFolderSwipeSwitching': 'Swipe to Switch Chat Folders',
   'appearanceShowChatListSearch': "Show Chat List Search",
   'appearanceShowEditAndReadMarks': "Show Edit and Read Marks",

--- a/lib/l10n/messages/es.dart
+++ b/lib/l10n/messages/es.dart
@@ -125,6 +125,7 @@ const esMessages = <String, String>{
   'appearanceRoundGroupAvatars': "Mostrar avatares de grupos redondos",
   'appearanceSearchFont': "Buscar fuente",
   'appearanceDisableChatListSwipeActions': 'Desactivar acciones de deslizamiento en la lista de chats',
+  'appearanceDisplayOwnChatAsFavorites': 'Mostrar como mensajes guardados en la lista de chats',
   'appearanceChatListFolderSwipeSwitching': 'Deslizar para cambiar de carpeta de chats',
   'appearanceShowChatListSearch': "Mostrar búsqueda en la lista de chats",
   'appearanceShowEditAndReadMarks': "Mostrar marcas de edición y lectura",

--- a/lib/l10n/messages/fr.dart
+++ b/lib/l10n/messages/fr.dart
@@ -127,6 +127,7 @@ const frMessages = <String, String>{
   'appearanceRoundGroupAvatars': "Afficher les avatars de groupe en cercle",
   'appearanceSearchFont': "Rechercher une police",
   'appearanceDisableChatListSwipeActions': 'Désactiver les actions de balayage de la liste de chats',
+  'appearanceDisplayOwnChatAsFavorites': 'Afficher comme messages enregistrés dans la liste de chats',
   'appearanceChatListFolderSwipeSwitching': 'Balayer pour changer de dossier de chats',
   'appearanceShowChatListSearch': "Afficher la recherche dans la liste",
   'appearanceShowEditAndReadMarks':

--- a/lib/l10n/messages/ja.dart
+++ b/lib/l10n/messages/ja.dart
@@ -121,6 +121,7 @@ const jaMessages = <String, String>{
   'appearanceRoundGroupAvatars': "グループチャットのアイコンを丸く表示",
   'appearanceSearchFont': "フォントを検索",
   'appearanceDisableChatListSwipeActions': 'チャットリストのスワイプアクションを無効化',
+  'appearanceDisplayOwnChatAsFavorites': 'チャットリストに保存済みメッセージとして表示',
   'appearanceChatListFolderSwipeSwitching': 'スワイプでチャットフォルダーを切り替え',
   'appearanceShowChatListSearch': "チャットリスト検索を表示",
   'appearanceShowEditAndReadMarks': "編集済み・既読マークを表示",

--- a/lib/l10n/messages/ko.dart
+++ b/lib/l10n/messages/ko.dart
@@ -121,6 +121,7 @@ const koMessages = <String, String>{
   'appearanceRoundGroupAvatars': "그룹 채팅 프로필을 원형으로 표시",
   'appearanceSearchFont': "글꼴 검색",
   'appearanceDisableChatListSwipeActions': '채팅 목록 스와이프 동작 비활성화',
+  'appearanceDisplayOwnChatAsFavorites': '채팅 목록에 저장된 메시지로 표시',
   'appearanceChatListFolderSwipeSwitching': '스와이프로 채팅 폴더 전환',
   'appearanceShowChatListSearch': "채팅 목록 검색 표시",
   'appearanceShowEditAndReadMarks': "수정 및 읽음 표시 보이기",

--- a/lib/l10n/messages/zh_hans.dart
+++ b/lib/l10n/messages/zh_hans.dart
@@ -118,6 +118,7 @@ const zhHansMessages = <String, String>{
   'appearanceRoundGroupAvatars': "群聊头像显示为圆形",
   'appearanceSearchFont': "搜索字体",
   'appearanceDisableChatListSwipeActions': '禁用聊天列表侧滑选项',
+  'appearanceDisplayOwnChatAsFavorites': '聊天列表显示为收藏夹',
   'appearanceChatListFolderSwipeSwitching': '滑动切换聊天文件夹',
   'appearanceShowChatListSearch': "显示聊天列表搜索",
   'appearanceShowEditAndReadMarks': "显示编辑和已读标记",

--- a/lib/l10n/messages/zh_hant.dart
+++ b/lib/l10n/messages/zh_hant.dart
@@ -119,6 +119,7 @@ const zhHantMessages = <String, String>{
   'appearanceRoundGroupAvatars': "群組頭像顯示為圓形",
   'appearanceSearchFont': "搜尋字型",
   'appearanceDisableChatListSwipeActions': '禁用聊天列表側滑選項',
+  'appearanceDisplayOwnChatAsFavorites': '聊天列表顯示為收藏夾',
   'appearanceChatListFolderSwipeSwitching': '滑動切換聊天資料夾',
   'appearanceShowChatListSearch': "顯示聊天列表搜尋",
   'appearanceShowEditAndReadMarks': "顯示編輯與已讀標記",

--- a/lib/settings/appearance_view.dart
+++ b/lib/settings/appearance_view.dart
@@ -359,6 +359,15 @@ class DisplaySettingsView extends StatelessWidget {
                   ),
                   _toggleRow(
                     context,
+                    HeroAppIcons.thumbtack.data,
+                    AppStrings.t(
+                      AppStringKeys.appearanceDisplayOwnChatAsFavorites,
+                    ),
+                    theme.displayOwnChatAsFavorites,
+                    (v) => theme.displayOwnChatAsFavorites = v,
+                  ),
+                  _toggleRow(
+                    context,
                     HeroAppIcons.pictureInPicture.data,
                     AppStrings.t(
                       AppStringKeys.appearanceDisableChatListSwipeActions,

--- a/lib/theme/theme_controller.dart
+++ b/lib/theme/theme_controller.dart
@@ -833,6 +833,8 @@ class ThemeController extends ChangeNotifier {
     _chatListFolderSwipeSwitching =
         _disableChatListSwipeActions &&
         (_prefs.getBool(_chatListFolderSwipeSwitchingKey) ?? false);
+    _displayOwnChatAsFavorites =
+        _prefs.getBool(_displayOwnChatAsFavoritesKey) ?? false;
     _hideSidebarPhone = _prefs.getBool(_hideSidebarPhoneKey) ?? false;
     _showMemberTags = _prefs.getBool(_memberTagsKey) ?? false;
     _showPremiumNameColors = _prefs.getBool(_premiumNameColorsKey) ?? true;
@@ -884,6 +886,7 @@ class ThemeController extends ChangeNotifier {
   static const _disableChatListSwipeActionsKey = 'disableChatListSwipeActions';
   static const _chatListFolderSwipeSwitchingKey =
       'chatListFolderSwipeSwitching';
+  static const _displayOwnChatAsFavoritesKey = 'displayOwnChatAsFavorites';
   static const _hideSidebarPhoneKey = 'hideSidebarPhone';
   static const _memberTagsKey = 'showMemberTags';
   static const _premiumNameColorsKey = 'showPremiumNameColors';
@@ -922,6 +925,7 @@ class ThemeController extends ChangeNotifier {
   bool _showChatListSearch = true;
   bool _disableChatListSwipeActions = false;
   bool _chatListFolderSwipeSwitching = false;
+  bool _displayOwnChatAsFavorites = false;
   bool _hideSidebarPhone = false;
   bool _showMemberTags = false;
   bool _showPremiumNameColors = true;
@@ -977,6 +981,7 @@ class ThemeController extends ChangeNotifier {
   bool get showChatListSearch => _showChatListSearch;
   bool get disableChatListSwipeActions => _disableChatListSwipeActions;
   bool get chatListFolderSwipeSwitching => _chatListFolderSwipeSwitching;
+  bool get displayOwnChatAsFavorites => _displayOwnChatAsFavorites;
   bool get hideSidebarPhone => _hideSidebarPhone;
   bool get showMemberTags => _showMemberTags;
   bool get showPremiumNameColors => _showPremiumNameColors;
@@ -1290,6 +1295,12 @@ class ThemeController extends ChangeNotifier {
     if (_chatFolderDisplayMode == value) return;
     _chatFolderDisplayMode = value;
     _prefs.setString(_chatFolderDisplayModeKey, value.name);
+    notifyListeners();
+  }
+
+  set displayOwnChatAsFavorites(bool value) {
+    _displayOwnChatAsFavorites = value;
+    _prefs.setBool(_displayOwnChatAsFavoritesKey, value);
     notifyListeners();
   }
 


### PR DESCRIPTION
## Changes

在设置 → 显示 → 聊天列表中添加了一个「聊天列表显示为收藏夹」开关，默认关闭。

### 开启后效果
- 聊天列表头部头像替换为蓝色书签图标
- 昵称区域显示「收藏夹」而非用户自己的名字
- 隐藏在线状态、emoji 状态和 Premium 标识

### 不开启
保持原有行为，显示自己的头像、名字和状态。

### 实现细节
- `ThemeController` 新增 `displayOwnChatAsFavorites` 布尔属性，通过 `SharedPreferences` 持久化
- 8 种语言的 l10n 翻译已同步添加