### PR TITLE
Fix ❤️ and 🕊️ reaction emoji not responding to tap

### DIFF
--- a/lib/chat/chat_view_model.dart
+++ b/lib/chat/chat_view_model.dart
@@ -2389,7 +2389,10 @@ class ChatViewModel extends ChangeNotifier {
       '@type': 'addMessageReaction',
       'chat_id': chatId,
       'message_id': messageId,
-      'reaction_type': {'@type': 'reactionTypeEmoji', 'emoji': emoji},
+      'reaction_type': {
+        '@type': 'reactionTypeEmoji',
+        'emoji': emoji.replaceAll(RegExp('[\uFE0E\uFE0F]'), ''),
+      },
       'is_big': false,
       'update_recent_reactions': true,
     });


### PR DESCRIPTION
## Problem

When tapping the ❤️ (heart) or 🕊️ (dove) emoji in the quick reaction bar or expanded reaction picker, the reaction silently fails and does not appear on the message. Other emoji reactions (👍, 🔥, 🎉, etc.) work correctly.

## Root Cause

The hardcoded `_quickReactions` and `_allReactions` lists include emoji characters with Unicode variation selector 16 (U+FE0F). For example:

- `'❤️'` = U+2764 + U+FE0F (not just U+2764)
- `'🕊️'` = U+1F54A + U+FE0F (not just U+1F54A)

TDLib's `addMessageReaction` API expects the canonical emoji form **without** variation selectors. When sent with VS16, the request silently fails.

This same issue affects other emojis with variation selectors in the `_allReactions` list (⚡️, ✍️, ☃️, etc.), though ❤️ is the most commonly used.

## Fix

Strip Unicode variation selectors (U+FE0E and U+FE0F) from the emoji string in `addReaction` before sending to TDLib, so any emoji from the picker is normalized to the canonical form TDLib expects.

This is consistent with how `topic_chat_view.dart` already handles the heart emoji — it maintains explicit fallback logic (`_topicHeartReactions`, `_alternateHeartReaction`) to try both forms. This fix makes the normalization automatic and universal.