### PR TITLE
Fix chat scroll instability during history loading

### DIFF
--- a/lib/chat/chat_view.dart
+++ b/lib/chat/chat_view.dart
@@ -375,6 +375,7 @@ class _ChatViewState extends State<ChatView> {
   double _backSwipeDy = 0;
   bool _backSwipePopping = false;
   bool _loadingOlderFromScroll = false;
+  bool _loadingOlderPreservingOffset = false;
   VelocityTracker? _backSwipeVelocity;
   dc.TabBarVisibility? _tabBarVisibility;
 
@@ -531,11 +532,14 @@ class _ChatViewState extends State<ChatView> {
       return;
     }
     _loadingOlderFromScroll = true;
+    _loadingOlderPreservingOffset = true;
     final oldPixels = _scroll.position.pixels;
     final oldMax = _scroll.position.maxScrollExtent;
     try {
       final loaded = await _vm.loadOlder();
       if (!loaded) return;
+      // Rebuild now that older messages are merged.
+      if (mounted) setState(() {});
       await WidgetsBinding.instance.endOfFrame;
       if (!mounted || !_scroll.hasClients || _scrollTargetId != null) return;
       final delta = _scroll.position.maxScrollExtent - oldMax;
@@ -544,10 +548,17 @@ class _ChatViewState extends State<ChatView> {
           _scroll.position.minScrollExtent,
           _scroll.position.maxScrollExtent,
         );
-        _scroll.jumpTo(target);
+        // Use correctBy instead of jumpTo so that an ongoing fling
+        // (ballistic scroll) is not killed by the position correction.
+        final pos = _scroll.position;
+        final correction = target - pos.pixels;
+        if (correction.abs() > 2.0) {
+          pos.correctBy(correction);
+        }
       }
     } finally {
       _loadingOlderFromScroll = false;
+      _loadingOlderPreservingOffset = false;
     }
   }
 
@@ -749,7 +760,9 @@ class _ChatViewState extends State<ChatView> {
         if (mounted) setState(() => _bannerDismissed = true);
       });
     }
-    setState(() {});
+    if (!_loadingOlderPreservingOffset) {
+      setState(() {});
+    }
   }
 
   int _firstUnreadIndex() => _vm.messages.indexWhere(


### PR DESCRIPTION
## Problem

When scrolling quickly up or down in a chat, the list would stutter, jump to the current message, and lose scroll inertia. This was caused by two issues in `_loadOlderPreservingOffset`:

1. **`jumpTo` kills scroll physics.** When oldPixels are corrected after prepending older messages, `jumpTo` creates an `IdleScrollActivity` that terminates any ongoing `BallisticScrollActivity` (inertial fling) or `DragScrollActivity` (active drag).

2. **Mid-load rebuilds shift content prematurely.** During `loadOlder()`, the `_merge` call triggers `notifyListeners` → `_onModel` → `setState`, which rebuilds the `ListView` with new content dimensions before the position correction runs, causing visible content shift.

## Fix

- Replace `_scroll.jumpTo(target)` with `_scroll.position.correctBy(correction)` — adjusts scroll pixels in-place without disrupting ongoing scroll physics.
- Add `_loadingOlderPreservingOffset` flag that prevents `_onModel` from calling `setState` during the load. A single `setState` is called after `loadOlder()` returns, just before the position correction, so the user sees only one clean transition.

## Testing

- Flutter analyze passes with no issues.
- Manual verification: fast scroll up/down no longer causes inertia break or position jumps when older messages are loaded.