### PR TITLE
fix: scroll instability when prepending older messages

### DIFF
--- a/lib/chat/chat_view.dart
+++ b/lib/chat/chat_view.dart
@@ -531,7 +531,6 @@ class _ChatViewState extends State<ChatView> {
       return;
     }
     _loadingOlderFromScroll = true;
-    final oldPixels = _scroll.position.pixels;
     final oldMax = _scroll.position.maxScrollExtent;
     try {
       final loaded = await _vm.loadOlder();
@@ -540,14 +539,11 @@ class _ChatViewState extends State<ChatView> {
       if (!mounted || !_scroll.hasClients || _scrollTargetId != null) return;
       final delta = _scroll.position.maxScrollExtent - oldMax;
       if (delta > 1) {
-        final target = (oldPixels + delta).clamp(
-          _scroll.position.minScrollExtent,
-          _scroll.position.maxScrollExtent,
-        );
-        _scroll.jumpTo(target);
+        _scroll.position.correctBy(delta);
       }
     } finally {
       _loadingOlderFromScroll = false;
+      if (mounted) setState(() {});
     }
   }
 
@@ -749,7 +745,9 @@ class _ChatViewState extends State<ChatView> {
         if (mounted) setState(() => _bannerDismissed = true);
       });
     }
-    setState(() {});
+    if (!_loadingOlderFromScroll) {
+      setState(() {});
+    }
   }
 
   int _firstUnreadIndex() => _vm.messages.indexWhere(


### PR DESCRIPTION
## Problem

When scrolling up quickly in chat view to load older messages, the list stutters, jumps, and inertial scrolling is interrupted.

## Root Cause

Two issues in `_loadOlderPreservingOffset`:

1. **jumpTo kills scroll physics** — Any ongoing fling/inertial scroll is terminated when `jumpTo` is called to correct the scroll position after prepending messages.

2. **Premature rebuild** — `_merge` calls `notifyListeners` which triggers `_onModel` → `setState` before the position correction runs. This causes a visible content shift (one frame where items jump down) before `jumpTo` snaps them back.

## Fix

- Replace `jumpTo` with `correctBy` — adjusts scroll position without ending the current scroll activity, preserving physics.
- Add guard in `_onModel` to skip `setState` when `_loadingOlderFromScroll` is true, then call it in the `finally` block after position correction completes.

The visual result: older messages load while the user continues scrolling smoothly, with no visible content jump.