### PR TITLE
Fix Android crash when resuming from background

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,6 +42,7 @@ import 'settings/auto_download_media_controller.dart';
 import 'settings/developer_mode_controller.dart';
 import 'settings/keyword_blocker.dart';
 import 'settings/translation_controller.dart';
+import 'tdlib/td_client.dart';
 import 'theme/app_theme.dart';
 import 'theme/theme_controller.dart';
 
@@ -211,7 +212,7 @@ class MithkaApp extends StatefulWidget {
   State<MithkaApp> createState() => _MithkaAppState();
 }
 
-class _MithkaAppState extends State<MithkaApp> {
+class _MithkaAppState extends State<MithkaApp> with WidgetsBindingObserver {
   late final AuthManager _auth = AuthManager();
   late final ThemeController _theme = ThemeController(widget.prefs);
   late final TranslationController _translation = TranslationController(
@@ -234,6 +235,7 @@ class _MithkaAppState extends State<MithkaApp> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _theme.loadSelectedEmojiFontIfAvailable();
     _autoDownload.initialize(widget.prefs);
     _auth.start();
@@ -242,6 +244,19 @@ class _MithkaAppState extends State<MithkaApp> {
     unawaited(_accounts.recoverPendingAddOnStartup(_auth));
     NotificationController.shared.start();
     PushDeviceRegistrar.shared.start();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      TdClient.shared.restartReceiveIsolate();
+    }
   }
 
   ThemeData _themeData(Brightness brightness, ThemeController theme) {

--- a/lib/tdlib/td_client.dart
+++ b/lib/tdlib/td_client.dart
@@ -83,6 +83,11 @@ class TdClient {
   bool _isRunning = false;
   Timer? _debugReceiveTimer;
 
+  // Receive isolate management — stored as fields so we can restart on resume.
+  ReceivePort? _receivePort;
+  StreamSubscription<dynamic>? _receiveSub;
+  bool _receiveIsolateDead = false;
+
   // Request/response correlation, keyed by the "@extra" we attach.
   final Map<String, Completer<Map<String, dynamic>>> _pending = {};
   final Map<int, Completer<void>> _clientClosedWaiters = {};
@@ -162,23 +167,41 @@ class TdClient {
     if (kDebugMode) {
       _startDebugReceivePump();
     } else {
-      // Spawn the dedicated receive isolate.
-      final fromIsolate = ReceivePort();
-      await Isolate.spawn(
-        _receiveEntry,
-        fromIsolate.sendPort,
-        debugName: 'TDLibReceive',
-      );
-      fromIsolate.listen((message) {
-        // The isolate ships already-decoded maps so JSON parsing stays off
-        // the UI thread; the String branch is a safety net.
-        if (message is Map<String, dynamic>) {
-          _route(message);
-        } else if (message is String) {
-          _routeRaw(message);
-        }
-      });
+      _spawnReceiveIsolate();
     }
+  }
+
+  void _spawnReceiveIsolate() {
+    _receivePort?.close();
+    _receiveSub?.cancel();
+
+    final port = ReceivePort();
+    _receivePort = port;
+    _receiveIsolateDead = false;
+
+    Isolate.spawn(
+      _receiveEntry,
+      port.sendPort,
+      debugName: 'TDLibReceive',
+    );
+    _receiveSub = port.listen((message) {
+      if (message is Map<String, dynamic>) {
+        _route(message);
+      } else if (message is String) {
+        _routeRaw(message);
+      }
+    });
+  }
+
+  /// Restarts the receive isolate if it died (e.g. after app background→foreground
+  /// on Android where the FFI state became stale). Safe to call when healthy.
+  void restartReceiveIsolate() {
+    if (!_isRunning) return;
+    if (kDebugMode) return;
+    if (!_receiveIsolateDead) return;
+
+    debugPrint('🔑 [Mithka] restarting receive isolate after resume');
+    _spawnReceiveIsolate();
   }
 
   // MARK: - Account management
@@ -880,6 +903,16 @@ class TdClient {
 
     // Only surface the active account's updates to the UI.
     if (clientId == _activeClientId) _updates.add(object);
+
+    // Internal: receive isolate reported a fatal error (e.g. td_receive threw
+    // after Android background→foreground). Mark it dead so a later resume
+    // restarts it.
+    if (object.type == '_tdReceiveFatal') {
+      _receiveIsolateDead = true;
+      debugPrint(
+        '🔑 [Mithka] receive isolate died: ${object['error'] ?? 'unknown'}',
+      );
+    }
   }
 
   void _routeRaw(String message) {
@@ -1134,10 +1167,28 @@ class TdFreshSessionResult {
 /// tdjson library and pumps every incoming event back to the main isolate.
 /// Events are decoded here so the main isolate never pays for JSON parsing
 /// during TDLib bursts (login sync, file progress, …).
+///
+/// On Android, the OS may freeze the process when the app goes to background.
+/// After thaw, the native FFI state can be stale and td_receive may throw or
+/// crash. We catch the error, notify the main isolate, and exit gracefully —
+/// the main isolate will restart us on the next foreground transition.
 void _receiveEntry(SendPort toMain) {
-  final bindings = TdBindings.open();
+  TdBindings bindings;
+  try {
+    bindings = TdBindings.open();
+  } catch (e) {
+    toMain.send({'@type': '_tdReceiveFatal', 'error': e.toString()});
+    return;
+  }
+
   while (true) {
-    final event = bindings.receive(1.0);
+    String? event;
+    try {
+      event = bindings.receive(1.0);
+    } catch (e) {
+      toMain.send({'@type': '_tdReceiveFatal', 'error': e.toString()});
+      return;
+    }
     if (event == null) continue;
     try {
       final decoded = jsonDecode(event);


### PR DESCRIPTION
## Problem

On Android, when the app is sent to background (not swiped away) and then resumed, it crashes with a force-close error.

## Root Cause

The receive isolate calls `td_receive()` through FFI in a tight `while(true)` loop. When Android suspends the app process and later thaws it, the native TDLib state can become stale, and `td_receive()` may throw or cause a SIGSEGV. Without error handling, this brings down the entire process.

## Fix

Two-layer defence:

1. **Receive isolate resilience** — `_receiveEntry` now wraps `TdBindings.open()` and `bindings.receive()` in try-catch. On failure, it sends an internal `_tdReceiveFatal` message to the main isolate and exits cleanly instead of crashing the process.

2. **Auto-restart on resume** — `_MithkaAppState` implements `WidgetsBindingObserver`. When `didChangeAppLifecycleState(AppLifecycleState.resumed)` fires, it calls `TdClient.shared.restartReceiveIsolate()`, which spawns a fresh receive isolate if the previous one died.

`ReceivePort` and `StreamSubscription` are promoted from local variables to instance fields so the isolate can be re-spawned after death.

## Changes

- `lib/tdlib/td_client.dart` — 2 files changed
- `lib/main.dart`