### PR TITLE
fix: smooth reverse page transition to avoid perceived jank

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -452,22 +452,32 @@ class _NoRadiusPageTransitionsBuilder extends PageTransitionsBuilder {
     Widget child,
   ) {
     if (route.fullscreenDialog) {
+      final curved = CurvedAnimation(
+        parent: animation,
+        curve: Curves.easeOutCubic,
+        reverseCurve: Curves.easeOutCubic,
+      );
       final offset = Tween<Offset>(
         begin: const Offset(0, 0.08),
         end: Offset.zero,
-      ).animate(CurvedAnimation(parent: animation, curve: Curves.easeOutCubic));
+      ).animate(curved);
       return FadeTransition(
-        opacity: animation,
+        opacity: curved,
         child: SlideTransition(position: offset, child: child),
       );
     }
 
+    final curved = CurvedAnimation(
+      parent: animation,
+      curve: Curves.easeOutCubic,
+      reverseCurve: Curves.easeOutCubic,
+    );
     final offset = Tween<Offset>(
       begin: const Offset(0.08, 0),
       end: Offset.zero,
-    ).animate(CurvedAnimation(parent: animation, curve: Curves.easeOutCubic));
+    ).animate(curved);
     return FadeTransition(
-      opacity: animation,
+      opacity: curved,
       child: SlideTransition(position: offset, child: child),
     );
   }


### PR DESCRIPTION
## Problem

Right-swipe to exit a chat feels jerky — users perceive it as lag/stutter.

## Root Cause

`_NoRadiusPageTransitionsBuilder.buildTransitions` used `CurvedAnimation(parent: animation, curve: Curves.easeOutCubic)` without specifying `reverseCurve`. On reverse (pop), Flutter auto-flips the curve: `easeOutCubic` → `easeInCubic`.

The reversed `easeInCubic` causes the exit animation to start very slowly (the view barely moves for most of the duration), then suddenly slide out and fade at the very end. This slow-start / fast-finish motion is what users perceive as jank.

## Fix

Set `reverseCurve: Curves.easeOutCubic` so the reverse animation stays smooth and responsive — the view starts moving immediately at a comfortable pace, matching the forward transition feel.

Applied to both the regular horizontal slide transition and the fullscreenDialog vertical slide. The fade opacity also uses the corrected `curved` animation so it stays in sync with the slide.