### PR TITLE
fix: await network fetch when local history fails with seeded messages

### DIFF
--- a/lib/chat/chat_view_model.dart
+++ b/lib/chat/chat_view_model.dart
@@ -1958,7 +1958,6 @@ class ChatViewModel extends ChangeNotifier {
   }
 
   Future<void> _loadInitialLatestHistory() async {
-    final seeded = _allMessages.isNotEmpty;
     final localLoaded = await _fetchHistory(
       0,
       0,
@@ -1967,10 +1966,6 @@ class ChatViewModel extends ChangeNotifier {
       restorePosition: false,
     );
     if (!localLoaded) {
-      if (seeded || _allMessages.isNotEmpty) {
-        unawaited(_fetchHistory(0, 0, 40, restorePosition: false));
-        return;
-      }
       await _fetchHistory(0, 0, 40);
     } else {
       unawaited(_fetchHistory(0, 0, 40, restorePosition: false));


### PR DESCRIPTION
## Problem

Chat history randomly appears empty, requiring cache clear (delete local data) to recover. Messages are present on the server but don't render in the app.

## Root Cause

In `_loadInitialLatestHistory()`, when `_primeLastMessage` has already seeded a message and the local `getChatHistory` returns empty (e.g. due to TDLib local database inconsistency), the old code fired an `unawaited` network fetch and **returned immediately** — skipping the message-fill logic below:

```dart
if (!localLoaded) {
  if (seeded || _allMessages.isNotEmpty) {
    unawaited(_fetchHistory(0, 0, 40, restorePosition: false));
    return;  // ← skipped fill logic & _hasOlderHistory updates
  }
  await _fetchHistory(0, 0, 40);
}
```

If the unawaited network fetch also returned empty (TDLib database corruption), the chat stayed stuck with only the seeded last message — or completely empty if it was filtered — until the user cleared the local cache.

## Fix

Remove the seeded fast-path. When local load returns empty, always `await` the network fetch, then let the normal fill logic run with whatever messages were loaded. This ensures:

- Network fetch completes before `initialLoaded` is set
- The fill logic (`messages.length < 12`) runs after messages are available
- Chat doesn't render empty when the server has data

## Change

`lib/chat/chat_view_model.dart` — 5 lines removed.