### PR TITLE
fix: enable edit for photo/video messages with captions

### DIFF
--- a/lib/chat/chat_view.dart
+++ b/lib/chat/chat_view.dart
@@ -2232,11 +2232,20 @@ class _ChatViewState extends State<ChatView> {
       if (mediaStart == 0 &&
           (result.text != message.text ||
               !_sameFormattedEntities(result.entities, message.textEntities))) {
-        await _vm.editMessageText(
-          message.id,
-          result.text,
-          entities: result.entities,
-        );
+        if (message.contentType == 'messagePhoto' ||
+            message.contentType == 'messageVideo') {
+          await _vm.editMessageCaption(
+            message.id,
+            result.text,
+            entities: result.entities,
+          );
+        } else {
+          await _vm.editMessageText(
+            message.id,
+            result.text,
+            entities: result.entities,
+          );
+        }
       }
       final extras = result.attachments.skip(mediaStart).toList();
       if (extras.isNotEmpty) {

--- a/lib/chat/chat_view_model.dart
+++ b/lib/chat/chat_view_model.dart
@@ -1386,6 +1386,32 @@ class ChatViewModel extends ChangeNotifier {
     );
   }
 
+  Future<void> editMessageCaption(
+    int id,
+    String caption, {
+    List<Map<String, dynamic>> entities = const [],
+  }) async {
+    await _client.query({
+      '@type': 'editMessageCaption',
+      'chat_id': chatId,
+      'message_id': id,
+      'caption': {
+        '@type': 'formattedText',
+        'text': caption,
+        if (entities.isNotEmpty) 'entities': entities,
+      },
+    });
+    _replaceText(id, caption, edited: true, entities: TDParse.textEntities({
+      '@type': 'formattedText',
+      'text': caption,
+      'entities': entities,
+    }), customEmoji: TDParse.customEmojiEntitiesFrom(TDParse.textEntities({
+      '@type': 'formattedText',
+      'text': caption,
+      'entities': entities,
+    })));
+  }
+
   Future<void> editMessageMedia(
     int id,
     String path, {

--- a/lib/chat/message_action_menu.dart
+++ b/lib/chat/message_action_menu.dart
@@ -71,7 +71,10 @@ class MessageActionMenu extends StatelessWidget {
   static const preferredHeight = 152.0;
 
   bool get _isEditableTextMessage =>
-      message.contentType == 'messageText' && message.text.isNotEmpty;
+      message.text.isNotEmpty &&
+      (message.contentType == 'messageText' ||
+       message.contentType == 'messagePhoto' ||
+       message.contentType == 'messageVideo');
 
   bool get _hasCopyableText => message.text.trim().isNotEmpty;
 


### PR DESCRIPTION
## Problem

Messages that contain an image (photo or video) with a caption cannot trigger the edit action. The edit button never appears in the message action menu for these messages.

## Root cause

Two issues:

1. **Menu filter too narrow** — `_isEditableTextMessage` in `message_action_menu.dart` only matched `contentType == 'messageText'`, so photo and video messages with captions were excluded from the edit action.

2. **Wrong TDLib API for caption edits** — When editing a photo/video message caption (without replacing the media), `editMessageText` was called. TDLib's `editMessageText` is only valid for text/game messages; caption edits on media messages require `editMessageCaption`.

## Fix

- Broaden `_isEditableTextMessage` to also match `messagePhoto` and `messageVideo` content types when the message has non-empty text.
- Add `editMessageCaption` method in `chat_view_model.dart` that calls TDLib's `editMessageCaption` API and updates local state.
- Route caption-only edits in `_editMessage` through `editMessageCaption` instead of `editMessageText` for photo/video messages.