### PR TITLE
fix: prevent reaction bar ArrowDown from being pushed off-screen

### DIFF
--- a/lib/chat/chat_view.dart
+++ b/lib/chat/chat_view.dart
@@ -4201,12 +4201,20 @@ class _ChatViewState extends State<ChatView> {
               top: reactionTop,
               left: 10,
               right: 10,
-              child: Align(
-                alignment: align,
-                child: _reactionExpanded
-                    ? _expandedReactionPicker()
-                    : _quickReactionBar(),
-              ),
+              child: _reactionExpanded
+                  ? Align(
+                      alignment: align,
+                      child: _expandedReactionPicker(),
+                    )
+                  : SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      reverse: align == Alignment.centerRight,
+                      physics: const ClampingScrollPhysics(),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [_quickReactionBar()],
+                      ),
+                    ),
             ),
           if (showActionMenu)
             Positioned(


### PR DESCRIPTION
## Problem

When the Interface scale (Settings → Appearance → Interface Scale) is set large enough, the quick reaction bar Row overflows the screen width. The ArrowDown (chevronDown) button at the right end gets pushed out of view, making it impossible to tap and access the expanded emoji picker with additional rows.

This happens because the bar is placed inside an `Align` widget which gives loose constraints, allowing the Row to exceed the available screen width without clipping or scrolling.

## Fix

Wrap the quick reaction bar in a `SingleChildScrollView` with `scrollDirection: Axis.horizontal` so the bar can be scrolled horizontally when its content exceeds the available width.

- For incoming messages (left-aligned): normal horizontal scroll, starts at left
- For outgoing messages (right-aligned): `reverse: true` so the scroll starts at the right edge, keeping the chevronDown visible and allowing leftward scroll to see more emoji
- `ClampingScrollPhysics` prevents overscroll glow artifacts
- The expanded reaction picker (300px wide) is unaffected and still uses Align