### PR TITLE
Fix deleted messages remaining visible in chat

### DIFF
--- a/lib/chat/chat_view.dart
+++ b/lib/chat/chat_view.dart
@@ -3770,12 +3770,14 @@ class _ChatViewState extends State<ChatView> {
   bool _transcriptCacheGrouped = false;
   int _transcriptCacheUnreadCount = -1;
   int _transcriptCacheLastReadInboxId = -1;
+  int _transcriptCacheMessageVersion = -1;
 
   List<_TranscriptEntry> _transcriptEntries(bool groupImages) {
     final messages = _vm.messages;
     final cached = _transcriptCache;
     if (cached != null &&
         identical(_transcriptCacheMessages, messages) &&
+        _transcriptCacheMessageVersion == _vm.messageVersion &&
         _transcriptCacheGrouped == groupImages &&
         _transcriptCacheUnreadCount == _vm.unreadCount &&
         _transcriptCacheLastReadInboxId == _vm.lastReadInboxId) {
@@ -3785,6 +3787,7 @@ class _ChatViewState extends State<ChatView> {
     _transcriptCache = entries;
     _transcriptCacheMessages = messages;
     _transcriptCacheGrouped = groupImages;
+    _transcriptCacheMessageVersion = _vm.messageVersion;
     _transcriptCacheUnreadCount = _vm.unreadCount;
     _transcriptCacheLastReadInboxId = _vm.lastReadInboxId;
     _transcriptIndexByKey = {

--- a/lib/chat/chat_view.dart
+++ b/lib/chat/chat_view.dart
@@ -681,6 +681,18 @@ class _ChatViewState extends State<ChatView> {
   void _onModel() {
     if (!mounted) return;
     if (_vm.messages.length != _lastCount) {
+      final visibleMessageIds = _vm.messages
+          .map((message) => message.id)
+          .toSet();
+      _selectedMessageIds.removeWhere(
+        (messageId) => !visibleMessageIds.contains(messageId),
+      );
+      if (_selectedMessageIds.isEmpty) {
+        _selectionAnchorId = null;
+      } else if (!visibleMessageIds.contains(_selectionAnchorId)) {
+        _selectionAnchorId = _selectedMessageIds.first;
+      }
+
       final wasNearBottom = _isNearBottom(72);
       final previousNewestId = _lastNewestMessageId;
       final newest = _vm.messages.isEmpty ? null : _vm.messages.last;

--- a/lib/chat/chat_view_model.dart
+++ b/lib/chat/chat_view_model.dart
@@ -2517,7 +2517,7 @@ class ChatViewModel extends ChangeNotifier {
           _resolveRichMessagesIfNeeded(target);
         }
 
-      case 'updateMessageSendSucceeded':
+case 'updateMessageSendSucceeded':
         if (update.int64('chat_id') != chatId) return;
         final oldMessageId = update.int64('old_message_id');
         final rawSentMessage = update.obj('message');
@@ -2548,6 +2548,13 @@ class ChatViewModel extends ChangeNotifier {
           _MessageSendResult.failure(error),
         );
 
+      case 'mithkaChatHistoryCleared':
+        _allMessages = [];
+        messages = [];
+        _hasOlderHistory = false;
+        _pendingScrollToId = null;
+        _messageVersion++;
+        notifyListeners();
       case 'updateChat':
         final chat = update.obj('chat');
         if (chat == null || chat.int64('id') != chatId) return;
@@ -2590,6 +2597,7 @@ class ChatViewModel extends ChangeNotifier {
         messages = [];
         _hasOlderHistory = false;
         _pendingScrollToId = null;
+        _messageVersion++;
         notifyListeners();
 
       case 'mithkaChatLeft':

--- a/lib/chat/chat_view_model.dart
+++ b/lib/chat/chat_view_model.dart
@@ -159,6 +159,8 @@ class ChatViewModel extends ChangeNotifier {
 
   List<ChatMessage> messages = [];
   List<ChatMessage> _allMessages = [];
+  int _messageVersion = 0;
+  int get messageVersion => _messageVersion;
   String peerTitle;
   TdFileRef? peerPhoto;
   bool isGroup = false;
@@ -3322,6 +3324,7 @@ class ChatViewModel extends ChangeNotifier {
           : pinnedMessages[pinnedMessageIndex];
       pinnedDismissed = pinnedMessage == null ? false : pinnedDismissed;
     }
+    _messageVersion++;
     notifyListeners();
   }
 

--- a/lib/chat/chat_view_model.dart
+++ b/lib/chat/chat_view_model.dart
@@ -2517,7 +2517,7 @@ class ChatViewModel extends ChangeNotifier {
           _resolveRichMessagesIfNeeded(target);
         }
 
-case 'updateMessageSendSucceeded':
+      case 'updateMessageSendSucceeded':
         if (update.int64('chat_id') != chatId) return;
         final oldMessageId = update.int64('old_message_id');
         final rawSentMessage = update.obj('message');
@@ -2555,6 +2555,7 @@ case 'updateMessageSendSucceeded':
         _pendingScrollToId = null;
         _messageVersion++;
         notifyListeners();
+
       case 'updateChat':
         final chat = update.obj('chat');
         if (chat == null || chat.int64('id') != chatId) return;


### PR DESCRIPTION
## Summary

Invalidate the transcript memoization when messages are removed so deleted messages disappear immediately instead of remaining visible until the chat is reopened.

## Root cause

The message list is mutated in place during deletion. Transcript caching only checked list identity, so it reused stale entries after the view model notified listeners.

## Validation

- `flutter analyze lib/chat/chat_view.dart lib/chat/chat_view_model.dart`
- `git diff --check`