### PR TITLE
Fix edit message text selection and system menu

### DIFF
--- a/lib/chat/rich_text_composer_view.dart
+++ b/lib/chat/rich_text_composer_view.dart
@@ -202,10 +202,13 @@ class _RichTableDraft {
 }
 
 class _RichTextBlock {
-  _RichTextBlock(this.controller, this.focusNode);
+  _RichTextBlock(this.controller, this.focusNode, this.onTextChanged)
+    : lastText = controller.text;
 
   final EmojiTextEditingController controller;
   final FocusNode focusNode;
+  final VoidCallback onTextChanged;
+  String lastText;
 }
 
 class _RichContentBlock {
@@ -259,9 +262,16 @@ class _RichTextComposerViewState extends State<RichTextComposerView> {
     } else {
       controller.setFormattedText(text, entities);
     }
-    controller.addListener(_onEditorChanged);
     final focusNode = FocusNode();
-    final block = _RichTextBlock(controller, focusNode);
+    late final _RichTextBlock block;
+    void onTextChanged() {
+      if (controller.text == block.lastText) return;
+      block.lastText = controller.text;
+      if (mounted) setState(() {});
+    }
+
+    block = _RichTextBlock(controller, focusNode, onTextChanged);
+    controller.addListener(onTextChanged);
     focusNode.addListener(() {
       if (focusNode.hasFocus) _activeTextBlock = block;
     });
@@ -269,7 +279,7 @@ class _RichTextComposerViewState extends State<RichTextComposerView> {
   }
 
   void _disposeTextBlock(_RichTextBlock block) {
-    block.controller.removeListener(_onEditorChanged);
+    block.controller.removeListener(block.onTextChanged);
     block.controller.dispose();
     block.focusNode.dispose();
   }
@@ -278,10 +288,6 @@ class _RichTextComposerViewState extends State<RichTextComposerView> {
     final text = block.text;
     if (text != null) _disposeTextBlock(text);
     block.table?.dispose();
-  }
-
-  void _onEditorChanged() {
-    if (mounted) setState(() {});
   }
 
   void _submit() {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -151,6 +151,46 @@ void main() {
       expect(tester.takeException(), isNull);
       semantics.dispose();
     });
+
+    testWidgets('keeps the editable text state while selection changes', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          localizationsDelegates: [
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: RichTextComposerView(
+            initialText: 'select this text',
+            allowMedia: false,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final field = find.byType(TextField).first;
+      final editable = find.descendant(
+        of: field,
+        matching: find.byType(EditableText),
+      );
+      final editableBefore = tester.state<EditableTextState>(editable);
+      final controller = tester.widget<TextField>(field).controller!;
+
+      controller.selection = const TextSelection(
+        baseOffset: 0,
+        extentOffset: 6,
+      );
+      await tester.pump();
+
+      expect(tester.state<EditableTextState>(editable), same(editableBefore));
+      expect(
+        controller.selection,
+        const TextSelection(baseOffset: 0, extentOffset: 6),
+      );
+    });
   });
 
   group('ChatInputBar', () {


### PR DESCRIPTION
## Summary

- avoid rebuilding the rich text composer for selection-only controller notifications
- preserve the native EditableText state so selection handles can expand or shrink normally
- keep the platform copy, paste, and select-all menu usable while editing messages
- add a widget regression test for selection-state stability

## Validation

- `flutter analyze lib/chat/rich_text_composer_view.dart test/widget_test.dart`
- `flutter test test/widget_test.dart --plain-name "keeps the editable text state while selection changes"`