### PR TITLE
fix: make bio links/mentions clickable in profiles and channel posts

### DIFF
--- a/lib/channels/topic_post_content.dart
+++ b/lib/channels/topic_post_content.dart
@@ -13,6 +13,7 @@ import '../tdlib/json_helpers.dart';
 import '../tdlib/td_client.dart';
 import '../tdlib/td_models.dart';
 import '../theme/app_theme.dart';
+import '../profile/profile_detail_view.dart';
 
 class TopicPostContent extends StatelessWidget {
   const TopicPostContent({
@@ -46,6 +47,14 @@ class TopicPostContent extends StatelessWidget {
           maxLines: maxTextLines,
           overflow: textOverflow,
           style: textStyle,
+          onMentionTap: (userId, name) {
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) =>
+                    ProfileDetailView(userId: userId, name: name),
+              ),
+            );
+          },
         ),
       );
     }
@@ -181,6 +190,14 @@ class _TopicFileCard extends StatelessWidget {
                 text: caption,
                 entities: captionEntities,
                 style: captionStyle,
+                onMentionTap: (userId, name) {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) =>
+                          ProfileDetailView(userId: userId, name: name),
+                    ),
+                  );
+                },
               ),
             ],
           ],

--- a/lib/chat/message_replies_sheet.dart
+++ b/lib/chat/message_replies_sheet.dart
@@ -8,6 +8,7 @@ import '../tdlib/td_client.dart';
 import '../tdlib/td_models.dart';
 import '../theme/app_theme.dart';
 import '../theme/date_text.dart';
+import '../profile/profile_detail_view.dart';
 import 'telegram_rich_text.dart';
 
 Future<void> showMessageRepliesSheet({
@@ -321,6 +322,14 @@ class _MessageRepliesSheetState extends State<_MessageRepliesSheet> {
                     color: c.textPrimary,
                     decoration: TextDecoration.none,
                   ),
+                  onMentionTap: (userId, name) {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) =>
+                            ProfileDetailView(userId: userId, name: name),
+                      ),
+                    );
+                  },
                 ),
               ],
             ),

--- a/lib/chat/telegram_rich_text.dart
+++ b/lib/chat/telegram_rich_text.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
 
-import '../profile/profile_detail_view.dart';
 import '../tdlib/td_models.dart';
 import '../theme/app_theme.dart';
 import 'custom_emoji.dart';
@@ -20,6 +19,7 @@ class TelegramRichText extends StatefulWidget {
     this.overflow = TextOverflow.clip,
     this.onBotCommandTap,
     this.onHashtagTap,
+    this.onMentionTap,
     this.quoteBackgroundColor,
   });
 
@@ -31,6 +31,7 @@ class TelegramRichText extends StatefulWidget {
   final TextOverflow overflow;
   final ValueChanged<String>? onBotCommandTap;
   final ValueChanged<String>? onHashtagTap;
+  final void Function(int userId, String name)? onMentionTap;
   final Color? quoteBackgroundColor;
 
   @override
@@ -273,17 +274,14 @@ class _TelegramRichTextState extends State<TelegramRichText> {
 
     final mentionUserId = _mentionUserId(active);
     if (mentionUserId != null) {
-      final recognizer = TapGestureRecognizer()
-        ..onTap = () {
-          Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (_) =>
-                  ProfileDetailView(userId: mentionUserId, name: segment),
-            ),
-          );
-        };
-      _recognizers.add(recognizer);
-      return [TextSpan(text: segment, style: style, recognizer: recognizer)];
+      final onTap = widget.onMentionTap;
+      if (onTap != null) {
+        final recognizer = TapGestureRecognizer()
+          ..onTap = () => onTap(mentionUserId, segment);
+        _recognizers.add(recognizer);
+        return [TextSpan(text: segment, style: style, recognizer: recognizer)];
+      }
+      return [TextSpan(text: segment, style: style)];
     }
 
     final target = _entityTapTarget(segment, active);

--- a/lib/moments/moments_view.dart
+++ b/lib/moments/moments_view.dart
@@ -36,6 +36,7 @@ import '../tdlib/chat_membership.dart';
 import '../tdlib/json_helpers.dart';
 import '../tdlib/td_client.dart';
 import '../tdlib/td_models.dart';
+import '../profile/profile_detail_view.dart';
 import '../theme/app_theme.dart';
 import '../theme/date_text.dart';
 import 'story_viewer_view.dart';
@@ -2745,6 +2746,14 @@ class _DetailCommentTile extends StatelessWidget {
                           height: 1.28,
                           color: c.textPrimary,
                         ),
+                        onMentionTap: (userId, name) {
+                          Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) =>
+                                  ProfileDetailView(userId: userId, name: name),
+                            ),
+                          );
+                        },
                       ),
                     ],
                   ),
@@ -3416,6 +3425,14 @@ class ChannelPostRow extends StatelessWidget {
                   height: 1.35,
                   color: c.textPrimary,
                 ),
+                onMentionTap: (userId, name) {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) =>
+                          ProfileDetailView(userId: userId, name: name),
+                    ),
+                  );
+                },
               ),
             ],
             if (_hasReplyQuote) ...[
@@ -3617,6 +3634,14 @@ class _InlineComments extends StatelessWidget {
                       height: 1.25,
                       color: c.textPrimary,
                     ),
+                    onMentionTap: (userId, name) {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) =>
+                              ProfileDetailView(userId: userId, name: name),
+                        ),
+                      );
+                    },
                   ),
                 ],
               ),

--- a/lib/profile/profile_detail_view.dart
+++ b/lib/profile/profile_detail_view.dart
@@ -22,6 +22,7 @@ import '../chat/chat_search_view.dart';
 import '../chat/chat_view.dart';
 import '../chat/custom_emoji.dart';
 import '../chat/full_image_viewer.dart';
+import '../chat/telegram_rich_text.dart';
 import '../chat/voice_audio.dart';
 import '../components/app_icons.dart';
 import '../components/photo_avatar.dart';
@@ -52,6 +53,7 @@ class _ProfileDetailViewState extends State<ProfileDetailView> {
   String? _username;
   String _phone = '';
   String _bio = '';
+  List<MessageTextEntity> _bioEntities = const [];
   TdFileRef? _photo;
   bool _isOnline = false;
   bool _isPremium = false;
@@ -128,6 +130,7 @@ class _ProfileDetailViewState extends State<ProfileDetailView> {
       if (mounted) {
         setState(() {
           _bio = full.obj('bio')?.str('text') ?? '';
+          _bioEntities = TDParse.textEntities(full.obj('bio'));
           _birthday = _formatBirthday(full.obj('birthdate'));
           _location =
               full.obj('business_info')?.obj('location')?.str('address') ?? '';
@@ -584,11 +587,20 @@ class _ProfileDetailViewState extends State<ProfileDetailView> {
             Row(
               children: [
                 Expanded(
-                  child: Text(
-                    _bio,
+                  child: TelegramRichText(
+                    text: _bio,
+                    entities: _bioEntities,
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                     style: TextStyle(fontSize: 15, color: c.textPrimary),
+                    onMentionTap: (userId, name) {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) =>
+                              ProfileDetailView(userId: userId, name: name),
+                        ),
+                      );
+                    },
                   ),
                 ),
                 const SizedBox(width: 8),


### PR DESCRIPTION
## Problem

个人简介和频道帖子中的链接、用户名无法点击。TDLib 返回的 bio 是 formattedText 对象，包含 text 和 entities 字段，但当前只提取了纯文本，丢弃了实体信息（链接、@用户名等）。同样，TelegramRichText 中用户名的点击处理硬编码了 ProfileDetailView 路由，造成循环依赖，阻止了 profile_detail_view 使用 TelegramRichText。

## Root cause

1. **Bio entities 被丢弃** — profile_detail_view.dart 只提取 bio 的 text，忽略 entities
2. **循环依赖** — telegram_rich_text.dart import 了 profile_detail_view.dart，导致 profile_detail_view 无法反过来使用 TelegramRichText

## Fix

- 添加 onMentionTap 回调到 TelegramRichText，解除对 profile_detail_view 的硬编码依赖
- 更新所有 TelegramRichText 调用者传入 onMentionTap
- 在 profile_detail_view 中用 TelegramRichText 渲染 bio，使链接和用户名可点击

## Files changed

- telegram_rich_text.dart — 添加 onMentionTap 回调
- profile_detail_view.dart — 存储 bio entities，用 TelegramRichText 渲染
- moments_view.dart — 传入 onMentionTap
- message_replies_sheet.dart — 传入 onMentionTap
- topic_post_content.dart — 传入 onMentionTap

## Verification

- flutter analyze — 0 errors
- flutter test — 97/97 passed

> **注意**：群组/频道/机器人简介（getSupergroupFullInfo.description 等）当前在 mithka 中未被渲染，因此无需修改。