### PR TITLE
fix: supply MIME type when opening files so APK and other types route correctly on Android

### DIFF
--- a/lib/chat/file_detail_view.dart
+++ b/lib/chat/file_detail_view.dart
@@ -96,7 +96,8 @@ class _FileDetailViewState extends State<FileDetailView> {
   Future<void> _open() async {
     final p = _path;
     if (p == null) return;
-    final r = await OpenFilex.open(p);
+    final ext = widget.doc.ext.toLowerCase();
+    final r = await OpenFilex.open(p, type: _mimeForExt(ext));
     if (r.type != ResultType.done && mounted) {
       showToast(
         context,
@@ -104,6 +105,54 @@ class _FileDetailViewState extends State<FileDetailView> {
       );
     }
   }
+
+  /// Map a lowercase file extension (without the dot) to an Android MIME type.
+  /// TDLib download paths may not preserve the original extension, so we
+  /// supply the type explicitly so the system can route the intent correctly.
+  String? _mimeForExt(String ext) {
+    if (ext.isEmpty) return null;
+    return _mimeMap[ext];
+  }
+
+  static const _mimeMap = <String, String>{
+    'apk': 'application/vnd.android.package-archive',
+    'pdf': 'application/pdf',
+    'doc': 'application/msword',
+    'docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'ppt': 'application/vnd.ms-powerpoint',
+    'pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    'xls': 'application/vnd.ms-excel',
+    'xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'txt': 'text/plain',
+    'jpg': 'image/jpeg',
+    'jpeg': 'image/jpeg',
+    'png': 'image/png',
+    'gif': 'image/gif',
+    'svg': 'image/svg+xml',
+    'webp': 'image/webp',
+    'bmp': 'image/bmp',
+    'mp3': 'audio/mpeg',
+    'wav': 'audio/wav',
+    'ogg': 'audio/ogg',
+    'flac': 'audio/flac',
+    'aac': 'audio/aac',
+    'mp4': 'video/mp4',
+    'avi': 'video/x-msvideo',
+    'mkv': 'video/x-matroska',
+    'webm': 'video/webm',
+    'mov': 'video/quicktime',
+    'html': 'text/html',
+    'css': 'text/css',
+    'js': 'application/javascript',
+    'json': 'application/json',
+    'xml': 'text/xml',
+    'zip': 'application/zip',
+    'rar': 'application/x-rar-compressed',
+    '7z': 'application/x-7z-compressed',
+    'tar': 'application/x-tar',
+    'gz': 'application/gzip',
+    'csv': 'text/csv',
+  };
 
   @override
   void dispose() {


### PR DESCRIPTION
## Problem

On Android, tapping the "打开" (Open) button on an APK file had no response.

## Root Cause

TDLib download paths do not preserve the original file extension (e.g. `.apk`). The `open_filex` plugin determines the MIME type from the file path's extension on Android. When the path lacks an extension, it falls back to `*/*`, and the system cannot route the intent to the correct handler.

For APK files specifically, this means Android never launches the package installer.

## Fix

Extract the original extension from the document metadata (`widget.doc.ext`) and pass it as the explicit `type` parameter to `OpenFilex.open()`.

A static MIME type map covers the common file types that `open_filex`'s native code handles, plus a few extras. Unknown extensions get `null`, which preserves the existing fallback-to-path-extension behavior.