### PR TITLE
fix: render Saved Messages chat row with bookmark icon (replaces #17)

### DIFF
--- a/lib/chats/chat_list_view.dart
+++ b/lib/chats/chat_list_view.dart
@@ -199,6 +199,7 @@ class _ChatListViewState extends State<ChatListView> {
               0;
           _meIsPremium = me.boolean('is_premium') ?? false;
           _meId = me.int64('id');
+          _model.meId = _meId;
         });
       }
     } catch (_) {}
@@ -514,27 +515,11 @@ class _ChatListViewState extends State<ChatListView> {
           children: [
             GestureDetector(
               onTap: () => context.read<dc.DrawerController>().open(),
-              child: context.watch<ThemeController>().displayOwnChatAsFavorites
-                  ? Container(
-                      width: AppMetric.headerAvatarSize,
-                      height: AppMetric.headerAvatarSize,
-                      decoration: BoxDecoration(
-                        color: context.colors.linkBlue,
-                        borderRadius: BorderRadius.circular(
-                          AppMetric.headerAvatarSize / 2,
-                        ),
-                      ),
-                      child: AppIcon(
-                        HeroAppIcons.thumbtack,
-                        size: AppMetric.headerAvatarSize * 0.5,
-                        color: const Color(0xFFFFFFFF),
-                      ),
-                    )
-                  : PhotoAvatar(
-                      title: _meName,
-                      photo: _mePhoto,
-                      size: AppMetric.headerAvatarSize,
-                    ),
+              child: PhotoAvatar(
+                title: _meName,
+                photo: _mePhoto,
+                size: AppMetric.headerAvatarSize,
+              ),
             ),
             const SizedBox(width: AppSpacing.lg),
             Expanded(
@@ -547,11 +532,7 @@ class _ChatListViewState extends State<ChatListView> {
                     children: [
                       Flexible(
                         child: Text(
-                          context
-                                  .watch<ThemeController>()
-                                  .displayOwnChatAsFavorites
-                              ? '收藏夹'
-                              : _meName,
+                          _meName,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           style: TextStyle(
@@ -561,10 +542,7 @@ class _ChatListViewState extends State<ChatListView> {
                           ),
                         ),
                       ),
-                      if (_meStatusId != 0 &&
-                          !context
-                              .watch<ThemeController>()
-                              .displayOwnChatAsFavorites) ...[
+                      if (_meStatusId != 0) ...[
                         const SizedBox(width: AppSpacing.xs + 1),
                         GestureDetector(
                           behavior: HitTestBehavior.opaque,
@@ -579,11 +557,7 @@ class _ChatListViewState extends State<ChatListView> {
                           ),
                         ),
                       ],
-                      if (_meIsPremium &&
-                          _meStatusId != 0 &&
-                          !context
-                              .watch<ThemeController>()
-                              .displayOwnChatAsFavorites) ...[
+                      if (_meIsPremium && _meStatusId != 0) ...[
                         const SizedBox(width: AppSpacing.xs),
                         AppIcon(
                           HeroAppIcons.chevronDown,
@@ -593,31 +567,27 @@ class _ChatListViewState extends State<ChatListView> {
                       ],
                     ],
                   ),
-                  if (!context
-                      .watch<ThemeController>()
-                      .displayOwnChatAsFavorites) ...[
-                    const SizedBox(height: AppSpacing.xxs),
-                    Row(
-                      children: [
-                        Container(
-                          width: AppMetric.onlineDot,
-                          height: AppMetric.onlineDot,
-                          decoration: BoxDecoration(
-                            color: AppTheme.onlineDot,
-                            shape: BoxShape.circle,
-                          ),
+                  const SizedBox(height: AppSpacing.xxs),
+                  Row(
+                    children: [
+                      Container(
+                        width: AppMetric.onlineDot,
+                        height: AppMetric.onlineDot,
+                        decoration: BoxDecoration(
+                          color: AppTheme.onlineDot,
+                          shape: BoxShape.circle,
                         ),
-                        const SizedBox(width: AppSpacing.xs),
-                        Text(
-                          AppStringKeys.chatOnline.l10n(context),
-                          style: TextStyle(
-                            fontSize: AppTextSize.caption,
-                            color: c.textSecondary,
-                          ),
+                      ),
+                      const SizedBox(width: AppSpacing.xs),
+                      Text(
+                        AppStringKeys.chatOnline.l10n(context),
+                        style: TextStyle(
+                          fontSize: AppTextSize.caption,
+                          color: c.textSecondary,
                         ),
-                      ],
-                    ),
-                  ],
+                      ),
+                    ],
+                  ),
                 ],
               ),
             ),

--- a/lib/chats/chat_list_view_model.dart
+++ b/lib/chats/chat_list_view_model.dart
@@ -63,6 +63,7 @@ class ChatListViewModel extends ChangeNotifier {
   final TdClient _client = TdClient.shared;
   StreamSubscription? _sub;
   bool _listening = false;
+  int? _meId;
   bool _prefetchingMain = false;
   final Set<String> _loadingChatLists = {};
   final Set<String> _exhaustedChatLists = {};
@@ -78,6 +79,18 @@ class ChatListViewModel extends ChangeNotifier {
     _loadFilters();
     _loadChats(_initialPageSize);
     _deferWarmCaches();
+  }
+
+  /// Called when the current user's id becomes known so we can flag the
+  /// Saved Messages chat (private chat with yourself).
+  set meId(int? value) {
+    if (_meId == value) return;
+    _meId = value;
+    if (value == null) return;
+    for (final s in _map.values) {
+      s.isSavedMessages = s.peerUserId == value;
+    }
+    notifyListeners();
   }
 
   @override
@@ -616,6 +629,7 @@ class ChatListViewModel extends ChangeNotifier {
       _removeChat(summary.id);
       return;
     }
+    if (_meId != null) summary.isSavedMessages = summary.peerUserId == _meId;
     summary.lastMessage = _previewText(summary.lastMessage);
     _map[summary.id] = summary;
     _applyPositions(summary.id, raw.objects('positions'));

--- a/lib/chats/chat_row_view.dart
+++ b/lib/chats/chat_row_view.dart
@@ -13,6 +13,7 @@ import '../chat/custom_emoji.dart';
 import '../components/app_icons.dart';
 import '../components/photo_avatar.dart';
 import '../components/ui_components.dart';
+import '../l10n/app_localizations.dart';
 import '../tdlib/td_models.dart';
 import '../theme/app_theme.dart';
 import '../theme/date_text.dart';
@@ -46,13 +47,15 @@ class ChatRowView extends StatelessWidget {
     final c = context.colors;
     final theme = context.watch<ThemeController>();
     final rowHeight = theme.rowHeight;
-    final premiumNameColor = theme.showPremiumNameColors && chat.peerIsPremium
+    final asFavorites = chat.isSavedMessages && theme.displayOwnChatAsFavorites;
+    final premiumNameColor = theme.showPremiumNameColors && chat.peerIsPremium && !asFavorites
         ? _accentColor(chat.peerAccentColorId)
         : c.textPrimary;
     final showPremiumStatus =
         theme.showPremiumEmojiStatus &&
         chat.peerIsPremium &&
-        chat.peerEmojiStatusId != 0;
+        chat.peerEmojiStatusId != 0 &&
+        !asFavorites;
     return Container(
       height: rowHeight,
       color: selected
@@ -72,12 +75,14 @@ class ChatRowView extends StatelessWidget {
                   children: [
                     Flexible(
                       child: Text(
-                        chat.title,
+                        asFavorites
+                            ? AppStringKeys.savedMessages.l10n(context)
+                            : chat.title,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: TextStyle(
                           fontSize: AppTextSize.body,
-                          fontWeight: chat.peerIsPremium
+                          fontWeight: chat.peerIsPremium && !asFavorites
                               ? FontWeight.w600
                               : FontWeight.w500,
                           color: premiumNameColor,
@@ -122,18 +127,33 @@ class ChatRowView extends StatelessWidget {
     final theme = context.watch<ThemeController>();
     final circleGroups = theme.circularGroupAvatars;
     final avatarSize = theme.avatarSize;
+    final asFavorites = chat.isSavedMessages && theme.displayOwnChatAsFavorites;
     return SizedBox(
       width: avatarSize,
       height: avatarSize,
       child: Stack(
         clipBehavior: Clip.none,
         children: [
-          PhotoAvatar(
-            title: chat.title,
-            photo: chat.photo,
-            size: avatarSize,
-            square: chat.usesSquareAvatar && !circleGroups,
-          ),
+          asFavorites
+              ? Container(
+                  width: avatarSize,
+                  height: avatarSize,
+                  decoration: BoxDecoration(
+                    color: context.colors.linkBlue,
+                    borderRadius: BorderRadius.circular(avatarSize / 2),
+                  ),
+                  child: AppIcon(
+                    HeroAppIcons.thumbtack,
+                    size: avatarSize * 0.5,
+                    color: const Color(0xFFFFFFFF),
+                  ),
+                )
+              : PhotoAvatar(
+                  title: chat.title,
+                  photo: chat.photo,
+                  size: avatarSize,
+                  square: chat.usesSquareAvatar && !circleGroups,
+                ),
           if (chat.unreadCount > 0)
             Positioned(
               right: 0,

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1251,6 +1251,7 @@ abstract final class AppStringKeys {
   static const richTextComposerRemoveColumn = 'richTextComposerRemoveColumn';
   static const richTextComposerRemoveRow = 'richTextComposerRemoveRow';
   static const richTextComposerRemoveTable = 'richTextComposerRemoveTable';
+  static const savedMessages = 'savedMessages';
   static const settingsAboutMithka = 'settingsAboutMithka';
   static const settingsLogOut = 'settingsLogOut';
   static const sharedMediaCacheDeleted = 'sharedMediaCacheDeleted';

--- a/lib/l10n/messages/de.dart
+++ b/lib/l10n/messages/de.dart
@@ -901,6 +901,7 @@ const deMessages = <String, String>{
   'richTextComposerRemoveColumn': "Spalte entfernen",
   'richTextComposerRemoveRow': "Zeile entfernen",
   'richTextComposerRemoveTable': "Tabelle entfernen",
+  'savedMessages': "Gespeicherte Nachrichten",
   'settingsAboutMithka': "Über Mithka",
   'settingsLogOut': "Abmelden",
   'sharedMediaCacheDeleted': "Lokaler Cache gelöscht",

--- a/lib/l10n/messages/en.dart
+++ b/lib/l10n/messages/en.dart
@@ -874,6 +874,7 @@ const enMessages = <String, String>{
   'richTextComposerRemoveColumn': "Remove column",
   'richTextComposerRemoveRow': "Remove row",
   'richTextComposerRemoveTable': "Remove table",
+  'savedMessages': "Saved Messages",
   'settingsAboutMithka': "About Mithka",
   'settingsLogOut': "Log Out",
   'sharedMediaCacheDeleted': "Local cache deleted",

--- a/lib/l10n/messages/es.dart
+++ b/lib/l10n/messages/es.dart
@@ -895,6 +895,7 @@ const esMessages = <String, String>{
   'richTextComposerRemoveColumn': "Eliminar columna",
   'richTextComposerRemoveRow': "Eliminar fila",
   'richTextComposerRemoveTable': "Eliminar tabla",
+  'savedMessages': "Mensajes guardados",
   'settingsAboutMithka': "Acerca de Mithka",
   'settingsLogOut': "Cerrar sesión",
   'sharedMediaCacheDeleted': "Caché local eliminada",

--- a/lib/l10n/messages/fr.dart
+++ b/lib/l10n/messages/fr.dart
@@ -902,6 +902,7 @@ const frMessages = <String, String>{
   'richTextComposerRemoveColumn': "Supprimer la colonne",
   'richTextComposerRemoveRow': "Supprimer la ligne",
   'richTextComposerRemoveTable': "Supprimer le tableau",
+  'savedMessages': "Messages enregistrés",
   'settingsAboutMithka': "À propos de Mithka",
   'settingsLogOut': "Se déconnecter",
   'sharedMediaCacheDeleted': "Cache local supprimé",

--- a/lib/l10n/messages/ja.dart
+++ b/lib/l10n/messages/ja.dart
@@ -843,6 +843,7 @@ const jaMessages = <String, String>{
   'richTextComposerRemoveColumn': "列を削除",
   'richTextComposerRemoveRow': "行を削除",
   'richTextComposerRemoveTable': "表を削除",
+  'savedMessages': "保存済みメッセージ",
   'settingsAboutMithka': "Mithka について",
   'settingsLogOut': "ログアウト",
   'sharedMediaCacheDeleted': "ローカルキャッシュを削除しました",

--- a/lib/l10n/messages/ko.dart
+++ b/lib/l10n/messages/ko.dart
@@ -842,6 +842,7 @@ const koMessages = <String, String>{
   'richTextComposerRemoveColumn': "열 삭제",
   'richTextComposerRemoveRow': "행 삭제",
   'richTextComposerRemoveTable': "표 삭제",
+  'savedMessages': "저장된 메시지",
   'settingsAboutMithka': "Mithka 정보",
   'settingsLogOut': "로그아웃",
   'sharedMediaCacheDeleted': "로컬 캐시 삭제됨",

--- a/lib/l10n/messages/zh_hans.dart
+++ b/lib/l10n/messages/zh_hans.dart
@@ -832,6 +832,7 @@ const zhHansMessages = <String, String>{
   'richTextComposerRemoveColumn': "删除列",
   'richTextComposerRemoveRow': "删除行",
   'richTextComposerRemoveTable': "删除表格",
+  'savedMessages': "收藏夹",
   'settingsAboutMithka': "关于 Mithka",
   'settingsLogOut': "退出登录",
   'sharedMediaCacheDeleted': "已删除本地缓存",

--- a/lib/l10n/messages/zh_hant.dart
+++ b/lib/l10n/messages/zh_hant.dart
@@ -832,6 +832,7 @@ const zhHantMessages = <String, String>{
   'richTextComposerRemoveColumn': "刪除欄",
   'richTextComposerRemoveRow': "刪除列",
   'richTextComposerRemoveTable': "刪除表格",
+  'savedMessages': "收藏夾",
   'settingsAboutMithka': "關於 Mithka",
   'settingsLogOut': "登出",
   'sharedMediaCacheDeleted': "已刪除本機快取",

--- a/lib/tdlib/td_models.dart
+++ b/lib/tdlib/td_models.dart
@@ -283,6 +283,7 @@ class ChatSummary {
     this.peerEmojiStatusId = 0,
     this.isForum = false,
     this.lastChatMessage,
+    this.isSavedMessages = false,
   });
 
   final int id;
@@ -307,6 +308,7 @@ class ChatSummary {
   int peerEmojiStatusId;
   bool isForum;
   ChatMessage? lastChatMessage;
+  bool isSavedMessages; // true when this is the Saved Messages chat (private chat with yourself)
 
   /// Groups & channels use a rounded-square avatar unless UI preferences
   /// override them; people use a circle.


### PR DESCRIPTION
## Problem

PR #17 was supposed to add a toggle that displays the Saved Messages chat (private chat with yourself) as "收藏夹" with a bookmark icon. Instead, it changed the **chat list header** avatar to a bookmark icon, which is the wrong target — the header should always show the user's own photo and name.

The user's intent was to change the **Saved Messages chat row** in the chat list, not the header.

## What this PR does

**Reverts the header changes** from #17 — the header once again always shows the user's own avatar, name, online status, emoji status, and premium indicator.

**Implements the feature at the chat row level:**
- Added `isSavedMessages` flag to `ChatSummary`, set when `peerUserId == meId`
- `ChatListViewModel` now tracks `meId` (passed from `ChatListViewState._loadMe()`) and flags the Saved Messages chat on ingest and when `meId` first becomes known
- `ChatRowView` renders a blue circular bookmark icon avatar and localized "Saved Messages" title for the Saved Messages chat row when `displayOwnChatAsFavorites` is enabled
- Premium name colors and emoji status are suppressed for this row
- Added `savedMessages` l10n key with translations for all 8 locales (en, zh-Hans, zh-Hant, ja, ko, fr, es, de)

## Files changed

- `lib/tdlib/td_models.dart` — `isSavedMessages` field on `ChatSummary`
- `lib/chats/chat_list_view_model.dart` — `meId` tracking + flag propagation
- `lib/chats/chat_list_view.dart` — revert header, pass `meId` to model
- `lib/chats/chat_row_view.dart` — bookmark icon avatar + localized title
- `lib/l10n/app_localizations.dart` — `savedMessages` key
- `lib/l10n/messages/*.dart` — translations (8 locales)

## Verification

`flutter analyze` passes with no errors or warnings related to these changes.