### PR TITLE
fix: gate swipe folder switching on top-tab folder display mode

### DIFF
--- a/lib/settings/appearance_view.dart
+++ b/lib/settings/appearance_view.dart
@@ -384,7 +384,9 @@ class DisplaySettingsView extends StatelessWidget {
                         AppStringKeys.appearanceChatListFolderSwipeSwitching,
                       ),
                       theme.chatListFolderSwipeSwitching,
-                      theme.disableChatListSwipeActions
+                      (theme.disableChatListSwipeActions &&
+                              theme.chatFolderDisplayMode ==
+                                  ChatFolderDisplayMode.tabs)
                           ? (v) => theme.chatListFolderSwipeSwitching = v
                           : null,
                     ),

--- a/lib/theme/theme_controller.dart
+++ b/lib/theme/theme_controller.dart
@@ -836,6 +836,7 @@ class ThemeController extends ChangeNotifier {
         _prefs.getBool(_disableChatListSwipeActionsKey) ?? false;
     _chatListFolderSwipeSwitching =
         _disableChatListSwipeActions &&
+        _chatFolderDisplayMode == ChatFolderDisplayMode.tabs &&
         (_prefs.getBool(_chatListFolderSwipeSwitchingKey) ?? false);
     _displayOwnChatAsFavorites =
         _prefs.getBool(_displayOwnChatAsFavoritesKey) ?? false;
@@ -1304,6 +1305,10 @@ class ThemeController extends ChangeNotifier {
     if (_chatFolderDisplayMode == value) return;
     _chatFolderDisplayMode = value;
     _prefs.setString(_chatFolderDisplayModeKey, value.name);
+    if (value != ChatFolderDisplayMode.tabs && _chatListFolderSwipeSwitching) {
+      _chatListFolderSwipeSwitching = false;
+      _prefs.setBool(_chatListFolderSwipeSwitchingKey, false);
+    }
     notifyListeners();
   }
 
@@ -1331,7 +1336,9 @@ class ThemeController extends ChangeNotifier {
   }
 
   set chatListFolderSwipeSwitching(bool value) {
-    final next = value && _disableChatListSwipeActions;
+    final next = value &&
+        _disableChatListSwipeActions &&
+        _chatFolderDisplayMode == ChatFolderDisplayMode.tabs;
     if (_chatListFolderSwipeSwitching == next) return;
     _chatListFolderSwipeSwitching = next;
     _prefs.setBool(_chatListFolderSwipeSwitchingKey, next);


### PR DESCRIPTION
## Problem

The "swipe to switch folders" toggle (`chatListFolderSwipeSwitching`) could be enabled even when chat folders were hidden or shown only as a top-right menu. In those modes there are no visible folder tabs to swipe between, so the option did nothing useful and was confusing.

## Solution

Gate the toggle so it can only be turned on when `chatFolderDisplayMode` is `tabs` (folders shown as top tabs). When the folder display mode changes away from `tabs`, swipe switching is automatically disabled and persisted.

## Changes

- `ThemeController`: `set chatFolderDisplayMode` now turns off `chatListFolderSwipeSwitching` when leaving `tabs` mode.
- `ThemeController`: `set chatListFolderSwipeSwitching` guards against enabling when folder mode is not `tabs`.
- `ThemeController`: load path also enforces the guard so stale prefs cannot re-enable it.
- `appearance_view`: the toggle UI is greyed out (disabled) unless folder mode is `tabs`, matching the controller logic.

The existing dependency on `disableChatListSwipeActions` is preserved — swipe switching still requires side-slide actions to be disabled first.