### PR TITLE
fix: position +1 repeat badge on left side for outgoing messages

### DIFF
--- a/lib/chat/message_bubble.dart
+++ b/lib/chat/message_bubble.dart
@@ -283,14 +283,14 @@ class _MessageBubbleState extends State<MessageBubble>
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
+                      if (widget.showRepeat) _repeatBadge(),
+                      if (widget.showRepeat) const SizedBox(width: 6),
                       Flexible(
                         child: Align(
                           alignment: Alignment.centerRight,
                           child: content,
                         ),
                       ),
-                      if (widget.showRepeat) const SizedBox(width: 6),
-                      if (widget.showRepeat) _repeatBadge(),
                     ],
                   ),
                 ),


### PR DESCRIPTION
## Problem

In group chats, when the user sends a "+1" repeat message, the repeat badge (circle) appears on the **right** side of the message bubble — sandwiched between the bubble and the user's own avatar. This looks inconsistent because incoming messages show the badge on the outer edge (right side, away from the avatar on the left), but outgoing messages show it on the inner edge (also right, next to the avatar).

## Fix

Move the repeat badge to the **left** of the content bubble for outgoing messages, so it sits on the outer edge — mirroring the incoming layout where the badge is always on the side away from the avatar.

### Before (outgoing)


### After (outgoing)


Incoming messages are unchanged — the badge stays on the right side of the incoming bubble.

## Changes

- `lib/chat/message_bubble.dart`: Reorder the `Row` children for the outgoing branch so `_repeatBadge()` and its spacer come **before** the `Flexible` content widget instead of after.