### PR TITLE
fix: prevent screen from sleeping during video playback

### DIFF
--- a/android/app/src/main/kotlin/ad/neko/mithka/MainActivity.kt
+++ b/android/app/src/main/kotlin/ad/neko/mithka/MainActivity.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
+import android.view.WindowManager
 import com.google.mlkit.common.model.DownloadConditions
 import com.google.mlkit.nl.translate.TranslateLanguage
 import com.google.mlkit.nl.translate.Translation
@@ -98,6 +99,25 @@ class MainActivity : FlutterActivity() {
                     result.success(listSystemFonts())
                 } else {
                     result.notImplemented()
+                }
+            }
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "mithka/screen_wakelock")
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "enable" -> {
+                        runOnUiThread {
+                            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                        }
+                        result.success(null)
+                    }
+                    "disable" -> {
+                        runOnUiThread {
+                            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                        }
+                        result.success(null)
+                    }
+                    else -> result.notImplemented()
                 }
             }
 

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -189,6 +189,23 @@ import UIKit
       }
     }
 
+    let wakelockChannel = FlutterMethodChannel(
+      name: "mithka/screen_wakelock",
+      binaryMessenger: engineBridge.applicationRegistrar.messenger()
+    )
+    wakelockChannel.setMethodCallHandler { call, result in
+      switch call.method {
+      case "enable":
+        UIApplication.shared.isIdleTimerDisabled = true
+        result(nil)
+      case "disable":
+        UIApplication.shared.isIdleTimerDisabled = false
+        result(nil)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
     let accountBackupChannel = FlutterMethodChannel(
       name: "mithka/account_backup",
       binaryMessenger: engineBridge.applicationRegistrar.messenger()

--- a/lib/chat/video_player_view.dart
+++ b/lib/chat/video_player_view.dart
@@ -19,6 +19,7 @@ import 'package:video_player/video_player.dart';
 import '../components/app_icons.dart';
 import '../components/photo_avatar.dart';
 import '../components/toast.dart';
+import '../platform/screen_wakelock.dart';
 import '../platform/system_picture_in_picture.dart';
 import '../tdlib/json_helpers.dart';
 import '../tdlib/td_client.dart';
@@ -375,6 +376,7 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
   bool _systemPiPPrepared = false;
   String? _systemPiPId;
   int _lastSystemPiPSyncMs = -1;
+  bool _wakelockActive = false;
 
   static const _speeds = <double>[0.5, 0.75, 1, 1.25, 1.5, 2];
   static const _resumePrefix = 'mithka.video.resume.';
@@ -497,6 +499,7 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
     }
     c.addListener(_onTick);
     setState(() => _controller = c);
+    _updateWakelock();
     unawaited(_refreshSystemPictureInPictureSupport());
     _scheduleHide();
     return true;
@@ -506,7 +509,21 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
   void _onTick() {
     _storePlaybackPositionIfNeeded();
     _syncSystemPictureInPictureIfNeeded();
+    _updateWakelock();
     if (mounted) setState(() {});
+  }
+
+  /// Keep the screen awake while the video is actively playing; release the
+  /// wakelock when paused or finished so the system idle timer resumes.
+  void _updateWakelock() {
+    final c = _controller;
+    if (c == null || !c.value.isInitialized) return;
+    final shouldKeepAwake = c.value.isPlaying;
+    if (shouldKeepAwake == _wakelockActive) return;
+    _wakelockActive = shouldKeepAwake;
+    unawaited(
+      shouldKeepAwake ? ScreenWakelock.enable() : ScreenWakelock.disable(),
+    );
   }
 
   void _syncSystemPictureInPictureIfNeeded() {
@@ -793,6 +810,10 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
   }
 
   void _close() {
+    if (_wakelockActive) {
+      _wakelockActive = false;
+      unawaited(ScreenWakelock.disable());
+    }
     unawaited(_storePlaybackPosition(force: true));
     final onClose = widget.onClose;
     if (onClose != null) {
@@ -804,6 +825,10 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
 
   @override
   void dispose() {
+    if (_wakelockActive) {
+      _wakelockActive = false;
+      unawaited(ScreenWakelock.disable());
+    }
     _hideTimer?.cancel();
     _progressSub?.cancel();
     unawaited(_storePlaybackPosition(force: true));

--- a/lib/platform/screen_wakelock.dart
+++ b/lib/platform/screen_wakelock.dart
@@ -1,0 +1,40 @@
+//
+//  screen_wakelock.dart
+//
+//  Keeps the screen awake during video playback by toggling the platform's
+//  idle-timer / keep-screen-on flag through a lightweight method channel.
+//  On Android this sets FLAG_KEEP_SCREEN_ON on the activity window; on iOS it
+//  disables UIApplication.idleTimerDisabled.  Calls are silently ignored on
+//  platforms without a registered handler (e.g. desktop), so the caller never
+//  needs to guard.
+//
+
+import 'package:flutter/services.dart';
+
+class ScreenWakelock {
+  ScreenWakelock._();
+
+  static const _channel = MethodChannel('mithka/screen_wakelock');
+
+  /// Prevent the screen from dimming or sleeping.
+  static Future<void> enable() async {
+    try {
+      await _channel.invokeMethod<void>('enable');
+    } on MissingPluginException {
+      // Platform has no handler — nothing to do.
+    } catch (_) {
+      // Best-effort; never let wakelock failures crash playback.
+    }
+  }
+
+  /// Restore the system's normal idle-timer behaviour.
+  static Future<void> disable() async {
+    try {
+      await _channel.invokeMethod<void>('disable');
+    } on MissingPluginException {
+      // Platform has no handler — nothing to do.
+    } catch (_) {
+      // Best-effort.
+    }
+  }
+}


### PR DESCRIPTION
## Problem

When playing a video, the system auto-screen-off (idle timer) kicks in and turns off the screen mid-playback.

## Fix

Added a lightweight `ScreenWakelock` platform service (`mithka/screen_wakelock` method channel) that toggles the platform idle-timer / keep-screen-on flag:

- **Android**: sets/clears `FLAG_KEEP_SCREEN_ON` on the activity window
- **iOS**: toggles `UIApplication.idleTimerDisabled`

The wakelock is enabled when video playback starts and released when the video is paused, finishes, or the player is closed/disposed. No third-party dependencies added — just a few lines of native code per platform, consistent with the existing method-channel pattern.

## Changes

- `lib/platform/screen_wakelock.dart` — new Dart service wrapping the method channel (silently no-ops on platforms without a handler)
- `android/.../MainActivity.kt` — register `mithka/screen_wakelock` channel
- `ios/Runner/AppDelegate.swift` — register `mithka/screen_wakelock` channel
- `lib/chat/video_player_view.dart` — enable wakelock on play, disable on pause/finish/close/dispose