### PR TITLE
fix: group member count garbled text and inaccurate count

### DIFF
--- a/lib/chat/chat_info_view.dart
+++ b/lib/chat/chat_info_view.dart
@@ -1373,6 +1373,7 @@ class ChatInfoViewModel extends ChangeNotifier {
           });
           final desc = info.str('description') ?? '';
           _setDescription(desc);
+          memberCount = info.integer('member_count') ?? memberCount;
         } catch (_) {}
       }
     } catch (_) {}
@@ -1476,10 +1477,15 @@ class ChatInfoViewModel extends ChangeNotifier {
           'limit': 30,
         });
         final raw = result.objects('members') ?? const <Map<String, dynamic>>[];
-        memberCount =
-            result.integer('member_count') ??
-            result.integer('total_count') ??
-            raw.length;
+        // _loadGroupMeta already set memberCount from the accurate
+        // getSupergroupFullInfo response; only fall back here when that
+        // was unavailable.
+        if (memberCount == 0) {
+          memberCount =
+              result.integer('member_count') ??
+              result.integer('total_count') ??
+              raw.length;
+        }
         await _resolveMembers(raw);
       }
     } catch (_) {}

--- a/lib/chat/chat_members_view.dart
+++ b/lib/chat/chat_members_view.dart
@@ -81,6 +81,16 @@ class _ChatMembersViewState extends State<ChatMembersView> {
       } else if (type?.type == 'chatTypeSupergroup') {
         final sgid = type?.int64('supergroup_id');
         if (sgid != null) {
+          // getSupergroupFullInfo has the accurate member_count;
+          // getSupergroupMembers only returns an approximate count.
+          int? fullCount;
+          try {
+            final fullInfo = await TdClient.shared.query({
+              '@type': 'getSupergroupFullInfo',
+              'supergroup_id': sgid,
+            });
+            fullCount = fullInfo.integer('member_count');
+          } catch (_) {}
           final res = await TdClient.shared.query({
             '@type': 'getSupergroupMembers',
             'supergroup_id': sgid,
@@ -89,7 +99,7 @@ class _ChatMembersViewState extends State<ChatMembersView> {
             'limit': 200,
           });
           raw = res.objects('members') ?? const <Map<String, dynamic>>[];
-          _total = res.integer('member_count') ?? raw.length;
+          _total = fullCount ?? res.integer('member_count') ?? raw.length;
         }
       }
       await _resolve(raw);

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1584,7 +1584,11 @@ abstract final class AppStrings {
     Map<String, Object?> placeholders,
   ) {
     if (placeholders.isEmpty) return value;
-    var result = value;
+    // Normalise fullwidth ％／＄ used in some CJK Telegram language
+    // packs so the replacement patterns below can match.
+    var result = value
+        .replaceAll('％', '%')
+        .replaceAll('＄', '\$');
     placeholders.forEach((placeholder, replacement) {
       final replacementText = '$replacement';
       result = result.replaceAll('{$placeholder}', replacementText);
@@ -1601,7 +1605,7 @@ abstract final class AppStrings {
   }
 
   static final _unresolvedPlaceholderPattern = RegExp(
-    r'\{value\d+\}|%\d+\$[@sd]|%[sd@]',
+    r'\{value\d+\}|[%％]\d+[\$＄][@sd]|[%％][sd@]',
   );
 
   static bool _hasUnresolvedPlaceholder(String value) =>

--- a/lib/l10n/telegram_language_controller.dart
+++ b/lib/l10n/telegram_language_controller.dart
@@ -418,7 +418,12 @@ class TelegramLanguageController extends ChangeNotifier {
     String template,
     Map<String, Object?> placeholders,
   ) {
-    var result = template;
+    // Some CJK Telegram language packs use fullwidth ％ (U+FF05) and
+    // ＄ (U+FF04) in printf-style format specifiers. Normalise them to
+    // ASCII so the replacement patterns below can match.
+    var result = template
+        .replaceAll('％', '%')
+        .replaceAll('＄', '\$');
     placeholders.forEach((key, value) {
       final replacement = '$value';
       result = result


### PR DESCRIPTION
## Problem

Group chat info menu showed raw `%1＄d` (fullwidth format specifier) instead of the actual member count, and the members detail page displayed a count that did not match the real number of members.

## Root Causes

**1. Fullwidth format specifiers not interpolated**

Some CJK Telegram language packs use fullwidth `％` (U+FF05) and `＄` (U+FF04) in printf-style format specifiers (e.g. `％1＄d members`). The interpolation code only matched ASCII `%1$d`, leaving the fullwidth variant unreplaced. The unresolved-placeholder fallback regex also only matched ASCII, so the garbled string was returned as-is instead of falling back to the app built-in localisation.

**2. Approximate member count from wrong TDLib call**

`getSupergroupMembers` returns an *approximate* `member_count`. The info view and members view both used this approximate value, which can differ from the real total. The accurate count is available from `getSupergroupFullInfo`.

## Fix

- **`telegram_language_controller.dart`** — normalise fullwidth `％`→`%` and `＄`→`$` at the start of `_interpolate` so existing replacement patterns match.
- **`app_localizations.dart`** — mirror the normalisation in `_interpolatePlaceholders` and extend `_unresolvedPlaceholderPattern` to detect fullwidth variants, ensuring proper fallback to built-in strings.
- **`chat_info_view.dart`** — extract `member_count` from `getSupergroupFullInfo` (already fetched in `_loadGroupMeta`); `_loadMembers` no longer overwrites it with the approximate value.
- **`chat_members_view.dart`** — fetch `getSupergroupFullInfo` for the accurate count, falling back to `getSupergroupMembers` only on failure.