### PR TITLE
feat: hide blocked users' messages in chats

### DIFF
--- a/lib/chat/chat_view.dart
+++ b/lib/chat/chat_view.dart
@@ -29,6 +29,7 @@ import '../components/toast.dart';
 import '../components/ui_components.dart';
 import '../l10n/telegram_language_controller.dart';
 import '../profile/profile_detail_view.dart';
+import '../settings/blocked_user_service.dart';
 import '../settings/developer_mode_controller.dart';
 import '../settings/keyword_blocker.dart';
 import '../settings/topic_group_display_mode.dart';
@@ -413,6 +414,9 @@ class _ChatViewState extends State<ChatView> {
     _vm.addListener(_onModel);
     _scrollTargetId = widget.initialMessageId;
     _vm.onAppear();
+    // Sync blocked-user-hiding toggle from theme.
+    final theme = context.read<ThemeController>();
+    BlockedUserService.shared.enabled = theme.hideBlockedUserMessages;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _retainTabBarSuppression();
     });
@@ -1375,6 +1379,22 @@ class _ChatViewState extends State<ChatView> {
           ),
           Expanded(child: Divider(color: c.divider, height: 1)),
         ],
+      ),
+    );
+  }
+
+  Widget _blockedMessagePlaceholder(BuildContext context) {
+    final c = context.colors;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Text(
+          '\u00B7 \u00B7 \u00B7',
+          style: TextStyle(
+            fontSize: 16,
+            color: c.textSecondary.withValues(alpha: 0.5),
+          ),
+        ),
       ),
     );
   }
@@ -2348,6 +2368,9 @@ class _ChatViewState extends State<ChatView> {
   @override
   Widget build(BuildContext context) {
     final c = context.colors;
+    // Keep blocked-user hiding toggle in sync with theme.
+    BlockedUserService.shared.enabled =
+        context.watch<ThemeController>().hideBlockedUserMessages;
     final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
     _syncKeyboardInset(keyboardInset);
     // Not a member, joinable, and nothing to preview → a custom join screen
@@ -3643,6 +3666,8 @@ class _ChatViewState extends State<ChatView> {
                 TimeSeparator(unix: message.date),
               if (message.isService)
                 SystemBanner(text: message.text)
+              else if (message.blockedByUser)
+                _blockedMessagePlaceholder(context)
               else if (entry.isImageGroup)
                 _selectionEntry(entry, _imageGroupBubble(entry.messages))
               else

--- a/lib/chat/chat_view_model.dart
+++ b/lib/chat/chat_view_model.dart
@@ -15,6 +15,7 @@ import 'package:mithka/l10n/app_localizations.dart';
 
 import '../l10n/telegram_language_controller.dart';
 import '../notifications/notification_settings_payload.dart';
+import '../settings/blocked_user_service.dart';
 import '../settings/keyword_blocker.dart';
 import '../tdlib/json_helpers.dart';
 import '../tdlib/td_client.dart';
@@ -2435,6 +2436,15 @@ class ChatViewModel extends ChangeNotifier {
           });
           notifyListeners();
         }
+
+      case 'updateBlockMessageSender':
+        // Invalidate blocked-user cache so the hide-on-block toggle
+        // takes effect immediately without app restart.
+        if (BlockedUserService.shared.enabled) {
+          unawaited(BlockedUserService.shared.loadBlockedUsers().then((_) {
+            _applyKeywordFilter();
+          }));
+        }
     }
   }
 
@@ -2791,8 +2801,27 @@ class ChatViewModel extends ChangeNotifier {
     messages =
         _allMessages.where((message) => !_isBlockedMessage(message)).toList()
           ..sort((a, b) => a.id.compareTo(b.id));
+    _markBlockedUserMessages();
     _markBlockedMessagesReadThroughVisibleBoundary();
     notifyListeners();
+  }
+
+  /// Mark messages from Telegram-blocked users so the renderer can show a
+  /// compact placeholder instead of the full bubble.
+  void _markBlockedUserMessages() {
+    final svc = BlockedUserService.shared;
+    if (!svc.enabled) {
+      for (final m in messages) {
+        m.blockedByUser = false;
+      }
+      return;
+    }
+    for (final m in messages) {
+      m.blockedByUser = !m.isOutgoing &&
+          !m.isService &&
+          m.senderId != null &&
+          svc.isBlocked(m.senderId!);
+    }
   }
 
   void _markBlockedMessagesReadThroughVisibleBoundary() {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -252,6 +252,8 @@ abstract final class AppStringKeys {
   static const appearanceManage = 'appearanceManage';
   static const appearanceMergeConsecutiveImages =
       'appearanceMergeConsecutiveImages';
+  static const appearanceHideBlockedUserMessages =
+      'appearanceHideBlockedUserMessages';
   static const appearanceMode = 'appearanceMode';
   static const appearanceMonospaceFont = 'appearanceMonospaceFont';
   static const appearanceNoCleanableFonts = 'appearanceNoCleanableFonts';

--- a/lib/l10n/messages/de.dart
+++ b/lib/l10n/messages/de.dart
@@ -117,6 +117,7 @@ const deMessages = <String, String>{
   'appearanceManage': "Verwalten",
   'appearanceMergeConsecutiveImages':
       "Aufeinanderfolgende Bilder zusammen anzeigen",
+  'appearanceHideBlockedUserMessages': "Nachrichten blockierter Nutzer ausblenden",
   'appearanceMode': "Modus",
   'appearanceMonospaceFont': "Monospace-Schrift",
   'appearanceNoCleanableFonts': "Nichts zu bereinigen",

--- a/lib/l10n/messages/en.dart
+++ b/lib/l10n/messages/en.dart
@@ -115,6 +115,7 @@ const enMessages = <String, String>{
   'appearanceInUseSize': "In Use",
   'appearanceManage': "Manage",
   'appearanceMergeConsecutiveImages': "Merge Consecutive Images",
+  'appearanceHideBlockedUserMessages': "Hide Blocked Users' Messages",
   'appearanceMode': "Mode",
   'appearanceMonospaceFont': "Monospace Font",
   'appearanceNoCleanableFonts': "Nothing to clean",

--- a/lib/l10n/messages/es.dart
+++ b/lib/l10n/messages/es.dart
@@ -116,6 +116,8 @@ const esMessages = <String, String>{
   'appearanceInUseSize': "En uso",
   'appearanceManage': "Gestionar",
   'appearanceMergeConsecutiveImages': "Combinar imágenes consecutivas",
+  'appearanceHideBlockedUserMessages':
+      "Ocultar mensajes de usuarios bloqueados",
   'appearanceMode': "Modo",
   'appearanceMonospaceFont': "Fuente monoespaciada",
   'appearanceNoCleanableFonts': "Nada para limpiar",

--- a/lib/l10n/messages/fr.dart
+++ b/lib/l10n/messages/fr.dart
@@ -118,6 +118,8 @@ const frMessages = <String, String>{
   'appearanceInUseSize': "En cours d’utilisation",
   'appearanceManage': "Gérer",
   'appearanceMergeConsecutiveImages': "Fusionner les images consécutives",
+  'appearanceHideBlockedUserMessages':
+      "Masquer les messages des utilisateurs bloqués",
   'appearanceMode': "Mode",
   'appearanceMonospaceFont': "Police monospace",
   'appearanceNoCleanableFonts': "Rien à nettoyer",

--- a/lib/l10n/messages/ja.dart
+++ b/lib/l10n/messages/ja.dart
@@ -112,6 +112,7 @@ const jaMessages = <String, String>{
   'appearanceInUseSize': "使用中",
   'appearanceManage': "管理",
   'appearanceMergeConsecutiveImages': "連続した画像をまとめて表示",
+  'appearanceHideBlockedUserMessages': "ブロックしたユーザーのメッセージを非表示",
   'appearanceMode': "モード",
   'appearanceMonospaceFont': "等幅フォント",
   'appearanceNoCleanableFonts': "クリーンアップ可能な項目なし",

--- a/lib/l10n/messages/ko.dart
+++ b/lib/l10n/messages/ko.dart
@@ -112,6 +112,7 @@ const koMessages = <String, String>{
   'appearanceInUseSize': "사용 중",
   'appearanceManage': "관리",
   'appearanceMergeConsecutiveImages': "연속 이미지를 합쳐서 표시",
+  'appearanceHideBlockedUserMessages': "차단한 사용자의 메시지 숨기기",
   'appearanceMode': "모드",
   'appearanceMonospaceFont': "고정폭 글꼴",
   'appearanceNoCleanableFonts': "정리할 항목 없음",

--- a/lib/l10n/messages/zh_hans.dart
+++ b/lib/l10n/messages/zh_hans.dart
@@ -109,6 +109,7 @@ const zhHansMessages = <String, String>{
   'appearanceInUseSize': "正在使用",
   'appearanceManage': "管理",
   'appearanceMergeConsecutiveImages': "连续图片合并显示",
+  'appearanceHideBlockedUserMessages': "隐藏已拉黑用户的消息",
   'appearanceMode': "模式",
   'appearanceMonospaceFont': "等宽字体",
   'appearanceNoCleanableFonts': "无可清理",

--- a/lib/l10n/messages/zh_hant.dart
+++ b/lib/l10n/messages/zh_hant.dart
@@ -110,6 +110,7 @@ const zhHantMessages = <String, String>{
   'appearanceInUseSize': "使用中",
   'appearanceManage': "管理",
   'appearanceMergeConsecutiveImages': "合併顯示連續圖片",
+  'appearanceHideBlockedUserMessages': "隱藏已封鎖使用者的訊息",
   'appearanceMode': "模式",
   'appearanceMonospaceFont': "等寬字型",
   'appearanceNoCleanableFonts': "沒有可清理項目",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,6 +39,7 @@ import 'notifications/notification_controller.dart';
 import 'notifications/push_device_registrar.dart';
 import 'settings/app_icon_controller.dart';
 import 'settings/auto_download_media_controller.dart';
+import 'settings/blocked_user_service.dart';
 import 'settings/developer_mode_controller.dart';
 import 'settings/keyword_blocker.dart';
 import 'settings/translation_controller.dart';
@@ -94,6 +95,8 @@ Future<void> _bootstrapAndRunApp() async {
   final prefs = await SharedPreferences.getInstance();
   KeywordBlocker.shared.initialize(prefs);
   MusicPlayerController.shared.initialize(prefs);
+  // Preload Telegram blocked-user list so chat filters have data right away.
+  unawaited(BlockedUserService.shared.loadBlockedUsers());
   // Firebase + analytics + Sentry tags are several platform-channel round
   // trips that nothing in the widget tree depends on — initialize them in
   // parallel with the first frame instead of blocking it.

--- a/lib/settings/appearance_view.dart
+++ b/lib/settings/appearance_view.dart
@@ -26,6 +26,7 @@ import '../theme/emoji_font_catalog.dart';
 import '../theme/system_font_catalog.dart';
 import '../theme/theme_controller.dart';
 import 'app_icon_controller.dart';
+import 'blocked_user_service.dart';
 
 class AppearanceView extends StatelessWidget {
   const AppearanceView({super.key});
@@ -334,6 +335,18 @@ class DisplaySettingsView extends StatelessWidget {
                     ),
                     theme.showChatPremiumEmojiStatus,
                     (v) => theme.showChatPremiumEmojiStatus = v,
+                  ),
+                  _toggleRow(
+                    context,
+                    HeroAppIcons.eyeSlash.data,
+                    AppStrings.t(
+                      AppStringKeys.appearanceHideBlockedUserMessages,
+                    ),
+                    theme.hideBlockedUserMessages,
+                    (v) {
+                      theme.hideBlockedUserMessages = v;
+                      if (v) BlockedUserService.shared.loadBlockedUsers();
+                    },
                   ),
                 ]),
                 const SizedBox(height: AppSpacing.xl),

--- a/lib/settings/blocked_user_service.dart
+++ b/lib/settings/blocked_user_service.dart
@@ -1,0 +1,66 @@
+//
+//  blocked_user_service.dart
+//
+//  Cached snapshot of Telegram blocked senders. Loaded once and kept fresh via
+//  TDLib updates, so group chats can optionally hide messages from blocked users.
+//
+
+import 'package:flutter/foundation.dart';
+
+import '../tdlib/td_client.dart';
+
+class BlockedUserService extends ChangeNotifier {
+  BlockedUserService._();
+  static final BlockedUserService shared = BlockedUserService._();
+
+  final Set<int> _blockedUserIds = {};
+
+  /// Whether the "hide blocked user messages" feature is enabled.
+  bool enabled = false;
+
+  bool get isLoaded => _blockedUserIds.isNotEmpty || _loaded;
+  bool _loaded = false;
+
+  bool isBlocked(int senderId) => _blockedUserIds.contains(senderId);
+
+  Future<void> loadBlockedUsers() async {
+    _blockedUserIds.clear();
+    _loaded = false;
+
+    try {
+      int offset = 0;
+      const int limit = 200;
+
+      while (true) {
+        final result = await TdClient.shared.query({
+          '@type': 'getBlockedMessageSenders',
+          'offset': offset,
+          'limit': limit,
+        });
+
+        final senders = result['senders'] as List<dynamic>?;
+        if (senders == null || senders.isEmpty) break;
+
+        for (final sender in senders) {
+          if (sender is Map<String, dynamic>) {
+            final senderData = sender['sender'] as Map<String, dynamic>?;
+            if (senderData != null && senderData['@type'] == 'messageSenderUser') {
+              final userId = senderData['user_id'];
+              if (userId is int) {
+                _blockedUserIds.add(userId);
+              }
+            }
+          }
+        }
+
+        if (senders.length < limit) break;
+        offset += limit;
+      }
+    } catch (_) {
+      // Graceful: on error just leave the existing cache or empty set.
+    }
+
+    _loaded = true;
+    notifyListeners();
+  }
+}

--- a/lib/tdlib/td_models.dart
+++ b/lib/tdlib/td_models.dart
@@ -370,6 +370,7 @@ class ChatMessage {
     this.hasCommentThread = false,
     this.commentCount = 0,
     this.lastCommentMessageId,
+    this.blockedByUser = false,
   });
 
   final int id;
@@ -440,6 +441,9 @@ class ChatMessage {
   int
   commentCount; // channel discussion replies/comments, when TDLib exposes it
   int? lastCommentMessageId;
+  /// When true, this message is from a Telegram-blocked user and the
+  /// "hide blocked user messages" feature is on.
+  bool blockedByUser;
   List<MessageReaction> reactions = const [];
   String? forwardOrigin; // name of the original author when forwarded
   int? forwardFromUserId; // origin user, resolved lazily to forwardOrigin

--- a/lib/theme/theme_controller.dart
+++ b/lib/theme/theme_controller.dart
@@ -847,6 +847,8 @@ class ThemeController extends ChangeNotifier {
         _prefs.getBool(_messageMetaIndicatorsKey) ?? false;
     _openChatsAtLatest = _prefs.getBool(_openChatsAtLatestKey) ?? false;
     _groupImageMessages = _prefs.getBool(_groupImageMessagesKey) ?? true;
+    _hideBlockedUserMessages =
+        _prefs.getBool(_hideBlockedUserMessagesKey) ?? false;
     _showChannelsTab = _prefs.getBool(_showChannelsTabKey) ?? false;
     _showMomentsTab = _prefs.getBool(_showMomentsTabKey) ?? true;
     _groupAssistantPlacement = GroupAssistantPlacement.values.firstWhere(
@@ -896,6 +898,7 @@ class ThemeController extends ChangeNotifier {
   static const _messageMetaIndicatorsKey = 'showMessageMetaIndicators';
   static const _openChatsAtLatestKey = 'openChatsAtLatest';
   static const _groupImageMessagesKey = 'groupImageMessages';
+  static const _hideBlockedUserMessagesKey = 'hideBlockedUserMessages';
   static const _showChannelsTabKey = 'showChannelsTab';
   static const _showMomentsTabKey = 'showMomentsTab';
   static const _groupAssistantPlacementKey = 'groupAssistantPlacement';
@@ -935,6 +938,7 @@ class ThemeController extends ChangeNotifier {
   bool _showMessageMetaIndicators = false;
   bool _openChatsAtLatest = false;
   bool _groupImageMessages = true;
+  bool _hideBlockedUserMessages = false;
   bool _showChannelsTab = false;
   bool _showMomentsTab = true;
   late GroupAssistantPlacement _groupAssistantPlacement;
@@ -991,6 +995,7 @@ class ThemeController extends ChangeNotifier {
   bool get showMessageMetaIndicators => _showMessageMetaIndicators;
   bool get openChatsAtLatest => _openChatsAtLatest;
   bool get groupImageMessages => _groupImageMessages;
+  bool get hideBlockedUserMessages => _hideBlockedUserMessages;
   bool get showChannelsTab => _showChannelsTab;
   bool get showMomentsTab => _showMomentsTab;
   GroupAssistantPlacement get groupAssistantPlacement =>
@@ -1380,6 +1385,12 @@ class ThemeController extends ChangeNotifier {
   set groupImageMessages(bool value) {
     _groupImageMessages = value;
     _prefs.setBool(_groupImageMessagesKey, value);
+    notifyListeners();
+  }
+
+  set hideBlockedUserMessages(bool value) {
+    _hideBlockedUserMessages = value;
+    _prefs.setBool(_hideBlockedUserMessagesKey, value);
     notifyListeners();
   }
 


### PR DESCRIPTION
## Summary

Add a new **Settings > Display > Chat Interface** toggle that hides messages from users you have blocked on Telegram. When enabled, messages from blocked users appear as a centered `· · ·` placeholder instead of the full message bubble.

## Changes

- **Toggle**: Settings > Display > Chat Interface, defaults to off
- **Placeholder**: Centered gray ellipsis for each hidden message (not a repeated banner)
- **Reactive**: Updates immediately when you toggle the setting or block/unblock a user while a chat is open
- **Localized**: zh-Hans, zh-Hant, en, de, es, fr, ja, ko

## Implementation

- `BlockedUserService` singleton caches Telegram's blocked sender list via TDLib `getBlockedMessageSenders`
- `ChatMessage.blockedByUser` flag marks filtered messages so they remain in the list but render as placeholders
- Reacts to TDLib `updateBlockMessageSender` to refresh the cache when blocking changes happen in-app
- Follows the existing `KeywordBlocker` / `ThemeController` setting pattern

## Screenshots

When toggle is on, messages from blocked users show as:

```
        · · ·
```

instead of the normal chat bubble.