### PR TITLE
Add proxy shortcut icon (gated by setting)

### DIFF
--- a/lib/chats/chat_list_view.dart
+++ b/lib/chats/chat_list_view.dart
@@ -14,6 +14,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:mithka/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../channels/forum_topic_browser_view.dart';
 import '../chat/chat_view.dart';
@@ -28,6 +29,7 @@ import '../contacts/add_people_view.dart';
 import '../contacts/create_group_view.dart';
 import '../profile/emoji_status_picker.dart';
 import '../settings/edit_field_view.dart';
+import '../settings/proxy_view.dart';
 import '../settings/topic_group_display_mode.dart';
 import '../tdlib/json_helpers.dart';
 import '../tdlib/td_client.dart';
@@ -124,6 +126,8 @@ class _ChatListViewState extends State<ChatListView> {
   bool _toggleUnreadTargetNext = true;
   bool _archiveRevealed = false;
   double _archivePullDistance = 0;
+  bool _showProxyIcon = false;
+  int _proxyStatusRequest = 0;
   int _lastVisibleRows = 1;
 
   ScrollController _newScrollController({double initialScrollOffset = 0}) {
@@ -141,6 +145,7 @@ class _ChatListViewState extends State<ChatListView> {
       if (mounted) _onControllerRequest();
     });
     _loadMe();
+    _loadProxyStatus();
     // Keep the header's name/status/photo live — TDLib emits updateUser for us
     // when the status or profile changes.
     _userSub = TdClient.shared.subscribe().listen((u) {
@@ -206,6 +211,33 @@ class _ChatListViewState extends State<ChatListView> {
         });
       }
     } catch (_) {}
+  }
+
+  Future<void> _loadProxyStatus() async {
+    final request = ++_proxyStatusRequest;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final shortcutEnabled = prefs.getBool('proxy_show_shortcut') ?? false;
+      if (!shortcutEnabled) {
+        if (mounted) setState(() => _showProxyIcon = false);
+        return;
+      }
+      final res = await TdClient.shared.query({'@type': 'getProxies'});
+      final list = res.objects('proxies') ?? const <Map<String, dynamic>>[];
+      if (!mounted || request != _proxyStatusRequest) return;
+      // Show the proxy shortcut only when at least one proxy exists.
+      setState(() => _showProxyIcon = list.isNotEmpty);
+    } catch (_) {
+      // A failed refresh must not overwrite the last known proxy state.
+    }
+  }
+
+  Future<void> _navigateToProxyView() async {
+    await Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (_) => const ProxyView()));
+    // Refresh in case the user added or removed a proxy.
+    if (mounted) unawaited(_loadProxyStatus());
   }
 
   Future<void> _openChat(ChatSummary chat) async {
@@ -633,6 +665,20 @@ class _ChatListViewState extends State<ChatListView> {
                   child: AppIcon(
                     HeroAppIcons.folder,
                     size: AppIconSize.toolbar,
+                    color: c.textPrimary,
+                  ),
+                ),
+              ),
+            if (_showProxyIcon)
+              GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: _navigateToProxyView,
+                child: SizedBox(
+                  width: AppMetric.hitTarget,
+                  height: AppMetric.hitTarget,
+                  child: AppIcon(
+                    HeroAppIcons.globe,
+                    size: AppIconSize.add,
                     color: c.textPrimary,
                   ),
                 ),

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1272,6 +1272,7 @@ abstract final class AppStringKeys {
   static const proxyPort = 'proxyPort';
   static const proxySecret = 'proxySecret';
   static const proxyServer = 'proxyServer';
+  static const proxyShowShortcut = 'proxyShowShortcut';
   static const proxyTitle = 'proxyTitle';
   static const qrCodeGroupTitle = 'qrCodeGroupTitle';
   static const qrCodeMineTitle = 'qrCodeMineTitle';

--- a/lib/l10n/messages/en.dart
+++ b/lib/l10n/messages/en.dart
@@ -902,6 +902,7 @@ const enMessages = <String, String>{
   'proxyPort': "Port",
   'proxySecret': "Secret",
   'proxyServer': "Server",
+  'proxyShowShortcut': "Show shortcut in chat list",
   'proxyTitle': "Proxy",
   'qrCodeGroupTitle': "Group QR code",
   'qrCodeMineTitle': "My QR code",

--- a/lib/settings/proxy_view.dart
+++ b/lib/settings/proxy_view.dart
@@ -14,6 +14,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:mithka/l10n/app_localizations.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../components/app_icons.dart';
 import '../components/confirm_dialog.dart';
@@ -35,11 +36,20 @@ class _ProxyViewState extends State<ProxyView> {
   final TdClient _client = TdClient.shared;
   List<Map<String, dynamic>> _proxies = [];
   bool _loading = true;
+  bool _showShortcut = false;
 
   @override
   void initState() {
     super.initState();
     _load();
+    _loadShortcutPref();
+  }
+
+  Future<void> _loadShortcutPref() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (mounted) {
+      setState(() => _showShortcut = prefs.getBool('proxy_show_shortcut') ?? false);
+    }
   }
 
   Future<void> _load() async {
@@ -55,6 +65,39 @@ class _ProxyViewState extends State<ProxyView> {
     } catch (_) {
       if (mounted) setState(() => _loading = false);
     }
+  }
+
+  Future<void> _toggleShortcut(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('proxy_show_shortcut', value);
+    if (mounted) setState(() => _showShortcut = value);
+  }
+
+  Widget _showShortcutToggle() {
+    final c = context.colors;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      child: SizedBox(
+        height: 52,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  AppStrings.t(AppStringKeys.proxyShowShortcut),
+                  style: TextStyle(fontSize: 16, color: c.textPrimary),
+                ),
+              ),
+              CupertinoSwitch(
+                value: _showShortcut,
+                onChanged: _toggleShortcut,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 
   bool get _anyEnabled => _proxies.any((p) => p.boolean('is_enabled') ?? false);
@@ -141,6 +184,8 @@ class _ProxyViewState extends State<ProxyView> {
                 : ListView(
                     padding: const EdgeInsets.fromLTRB(12, 14, 12, 24),
                     children: [
+                      _card([_showShortcutToggle()]),
+                      const SizedBox(height: 14),
                       _card([_noneRow()]),
                       if (_proxies.isNotEmpty) ...[
                         const SizedBox(height: 14),


### PR DESCRIPTION
## Summary

Add a proxy shortcut icon in the chat list header (top-right area) that opens the proxy settings view. The icon's visibility is controlled by a new toggle in Settings > Proxy, defaulting to off.

## Changes

- **ProxyView**: Added \"Show shortcut in chat list\" toggle at the top of the proxy settings page. Persisted via SharedPreferences, default off.
- **ChatListView**: Added proxy icon (globe) in the top-right toolbar area, visible only when the shortcut toggle is enabled **and** at least one proxy is configured. Tapping navigates to ProxyView; the icon refreshes after returning.
- **Localization**: Added `proxyShowShortcut` key.

## PR History

This replaces #10 (closed) with the same icon feature plus a user-facing toggle to control its visibility.