### PR TITLE
fix: center checkmark inside pinned message badge

### DIFF
--- a/lib/chat/chat_view.dart
+++ b/lib/chat/chat_view.dart
@@ -3500,16 +3500,17 @@ class _ChatViewState extends State<ChatView> {
         child: Row(
           children: [
             Container(
-              width: 16,
-              height: 16,
+              width: 18,
+              height: 18,
               decoration: BoxDecoration(
-                border: Border.all(color: const Color(0xFFFFB300), width: 2),
-                borderRadius: BorderRadius.circular(6),
+                color: const Color(0xFFFFB300),
+                borderRadius: BorderRadius.circular(5),
               ),
+              alignment: Alignment.center,
               child: const AppIcon(
                 HeroAppIcons.check,
-                size: 15,
-                color: Color(0xFFFFB300),
+                size: 12,
+                color: Colors.white,
               ),
             ),
             const SizedBox(width: 14),


### PR DESCRIPTION
## Summary

The pinned message badge (yellow rounded rectangle with a checkmark) had the checkmark misaligned: the icon appeared off-center inside the badge.

## Root cause

The badge was a 16×16 `Container` with a **2px yellow border** and no background fill, containing a **size-15** yellow checkmark icon. The 2px border on each side left only 12×12 pixels of visible inner area, but the icon was 15×15 — larger than the available space. The border overlapped the icon's edges, making the checkmark look off-center.

## Fix

- Replaced the hollow border-only decoration with a **solid yellow rounded rectangle** (18×18, `Color(0xFFFFB300)`, radius 5)
- Changed the checkmark icon to **white** and reduced its size to **12**
- Added explicit `Alignment.center` for visual certainty

## Validation

- `flutter analyze lib/chat/chat_view.dart` — No issues found
- `git diff --check` — clean