### PR TITLE
feat: 消息时间戳显示 + 开关

### DIFF
--- a/lib/chat/message_bubble.dart
+++ b/lib/chat/message_bubble.dart
@@ -576,11 +576,27 @@ class _MessageBubbleState extends State<MessageBubble>
               if (message.isEdited && outgoing) const SizedBox(width: 3),
               if (outgoing)
                 _deliveryDots(diameter: 4, color: AppTheme.bubbleOutgoingText),
+              if (context.read<ThemeController>().showMessageTimestamp)
+                Padding(
+                  padding: const EdgeInsets.only(left: 6),
+                  child: Text(
+                    _timestampLabel(message.date),
+                    style: TextStyle(fontSize: 10, color: faint),
+                  ),
+                ),
             ],
           ),
         ),
       ),
     );
+  }
+
+  String _timestampLabel(int sec) {
+    final date = DateTime.fromMillisecondsSinceEpoch(sec * 1000);
+    final h = date.hour.toString().padLeft(2, '0');
+    final m = date.minute.toString().padLeft(2, '0');
+    final s = date.second.toString().padLeft(2, '0');
+    return '$h:$m:$s';
   }
 
   Widget _stickerTap(Widget child) => GestureDetector(

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -283,6 +283,7 @@ abstract final class AppStringKeys {
   static const appearanceShowPremiumStatusEmoji =
       'appearanceShowPremiumStatusEmoji';
   static const appearanceShowUnreadChatCount = 'appearanceShowUnreadChatCount';
+  static const appearanceShowMessageTimestamp = 'appearanceShowMessageTimestamp';
   static const appearanceSize = 'appearanceSize';
   static const appearanceSystem = 'appearanceSystem';
   static const appearanceSystemEmojiFont = 'appearanceSystemEmojiFont';

--- a/lib/l10n/messages/en.dart
+++ b/lib/l10n/messages/en.dart
@@ -133,6 +133,7 @@ const enMessages = <String, String>{
   'appearanceShowChatListSearch': "Show Chat List Search",
   'appearanceShowEditAndReadMarks': "Show Edit and Read Marks",
   'appearanceShowGroupMemberTitles': "Show Group Member Titles",
+    'appearanceShowMessageTimestamp': "Show Message Timestamp",
   'appearanceShowPremiumNameColor': "Show Premium Name Color",
   'appearanceShowPremiumStatusEmoji': "Show Premium Status Emoji",
   'appearanceShowUnreadChatCount': "Show Unread Chat Count",

--- a/lib/l10n/messages/zh_hans.dart
+++ b/lib/l10n/messages/zh_hans.dart
@@ -127,6 +127,7 @@ const zhHansMessages = <String, String>{
   'appearanceShowChatListSearch': "显示聊天列表搜索",
   'appearanceShowEditAndReadMarks': "显示编辑和已读标记",
   'appearanceShowGroupMemberTitles': "群成员显示头衔",
+    'appearanceShowMessageTimestamp': "消息显示时间戳",
   'appearanceShowPremiumNameColor': "显示 Premium 名字颜色",
   'appearanceShowPremiumStatusEmoji': "显示 Premium 状态表情",
   'appearanceShowUnreadChatCount': "显示未读会话数",

--- a/lib/l10n/messages/zh_hant.dart
+++ b/lib/l10n/messages/zh_hant.dart
@@ -128,6 +128,7 @@ const zhHantMessages = <String, String>{
   'appearanceShowChatListSearch': "顯示聊天列表搜尋",
   'appearanceShowEditAndReadMarks': "顯示編輯與已讀標記",
   'appearanceShowGroupMemberTitles': "顯示群組成員頭銜",
+    'appearanceShowMessageTimestamp': "顯示消息時間戳",
   'appearanceShowPremiumNameColor': "顯示 Premium 名稱顏色",
   'appearanceShowPremiumStatusEmoji': "顯示 Premium 狀態 emoji",
   'appearanceShowUnreadChatCount': "顯示未讀聊天數",

--- a/lib/settings/appearance_view.dart
+++ b/lib/settings/appearance_view.dart
@@ -349,6 +349,15 @@ class DisplaySettingsView extends StatelessWidget {
                       if (v) BlockedUserService.shared.loadBlockedUsers();
                     },
                   ),
+                  _toggleRow(
+                    context,
+                    HeroAppIcons.clock.data,
+                    AppStrings.t(
+                      AppStringKeys.appearanceShowMessageTimestamp,
+                    ),
+                    theme.showMessageTimestamp,
+                    (v) => theme.showMessageTimestamp = v,
+                  ),
                 ]),
                 const SizedBox(height: AppSpacing.xl),
                 _label(context, AppStrings.t(AppStringKeys.appearanceChatList)),

--- a/lib/theme/theme_controller.dart
+++ b/lib/theme/theme_controller.dart
@@ -867,6 +867,7 @@ class ThemeController extends ChangeNotifier {
         _prefs.getBool(_chatPremiumEmojiStatusKey) ?? true;
     _showMessageMetaIndicators =
         _prefs.getBool(_messageMetaIndicatorsKey) ?? false;
+    _showMessageTimestamp = _prefs.getBool(_showMessageTimestampKey) ?? true;
     _openChatsAtLatest = _prefs.getBool(_openChatsAtLatestKey) ?? false;
     _preserveSenderWhenRepeating =
         _prefs.getBool(_preserveSenderWhenRepeatingKey) ?? true;
@@ -927,6 +928,7 @@ class ThemeController extends ChangeNotifier {
   static const _chatPremiumNameColorsKey = 'showChatPremiumNameColors';
   static const _chatPremiumEmojiStatusKey = 'showChatPremiumEmojiStatus';
   static const _messageMetaIndicatorsKey = 'showMessageMetaIndicators';
+  static const _showMessageTimestampKey = 'showMessageTimestamp';
   static const _openChatsAtLatestKey = 'openChatsAtLatest';
   static const _preserveSenderWhenRepeatingKey = 'preserveSenderWhenRepeating';
   static const _groupImageMessagesKey = 'groupImageMessages';
@@ -968,6 +970,7 @@ class ThemeController extends ChangeNotifier {
   bool _showChatPremiumNameColors = true;
   bool _showChatPremiumEmojiStatus = true;
   bool _showMessageMetaIndicators = false;
+  bool _showMessageTimestamp = true;
   bool _openChatsAtLatest = false;
   bool _preserveSenderWhenRepeating = true;
   bool _groupImageMessages = true;
@@ -1034,6 +1037,7 @@ class ThemeController extends ChangeNotifier {
   bool get showChatPremiumNameColors => _showChatPremiumNameColors;
   bool get showChatPremiumEmojiStatus => _showChatPremiumEmojiStatus;
   bool get showMessageMetaIndicators => _showMessageMetaIndicators;
+  bool get showMessageTimestamp => _showMessageTimestamp;
   bool get openChatsAtLatest => _openChatsAtLatest;
   bool get preserveSenderWhenRepeating => _preserveSenderWhenRepeating;
   bool get groupImageMessages => _groupImageMessages;
@@ -1418,6 +1422,12 @@ class ThemeController extends ChangeNotifier {
   set showMessageMetaIndicators(bool value) {
     _showMessageMetaIndicators = value;
     _prefs.setBool(_messageMetaIndicatorsKey, value);
+    notifyListeners();
+  }
+
+  set showMessageTimestamp(bool value) {
+    _showMessageTimestamp = value;
+    _prefs.setBool(_showMessageTimestampKey, value);
     notifyListeners();
   }
 


### PR DESCRIPTION
Add configurable HH:mm:ss send timestamp to chat bubbles, positioned bottom-right next to read/edited indicators. Add a Settings > Display > Chat view toggle (default on) to control it. Persist user preference via ThemeController.