### PR TITLE
feat: edge-to-edge status and navigation bars

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -120,6 +120,8 @@ flutter {
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
+    // Edge-to-edge: WindowCompat.setDecorFitsSystemWindows.
+    implementation("androidx.core:core-ktx:1.16.0")
     // ntgcalls — a from-scratch C++ Telegram-calls engine (WebRTC + opus + libvpx
     // statically bundled inside a self-contained libntgcalls.so per ABI). This is
     // the real media transport behind the CallMediaEngine seam; CallMediaPlugin

--- a/android/app/src/main/kotlin/ad/neko/mithka/MainActivity.kt
+++ b/android/app/src/main/kotlin/ad/neko/mithka/MainActivity.kt
@@ -7,11 +7,13 @@ import android.content.ClipDescription
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
+import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
 import android.view.DragEvent
 import android.view.WindowManager
 import android.webkit.MimeTypeMap
+import androidx.core.view.WindowCompat
 import com.google.mlkit.common.model.DownloadConditions
 import com.google.mlkit.nl.translate.TranslateLanguage
 import com.google.mlkit.nl.translate.Translation
@@ -32,6 +34,12 @@ class MainActivity : FlutterActivity() {
     private var mediaDropChannel: MethodChannel? = null
     private var acceptingImageDrop = false
     private val translators = mutableMapOf<String, Translator>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        // Let Flutter paint under the status bar and gesture/nav bar.
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        super.onCreate(savedInstanceState)
+    }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         registerPlugins(flutterEngine)

--- a/android/app/src/main/res/values-night-v29/styles.xml
+++ b/android/app/src/main/res/values-night-v29/styles.xml
@@ -1,26 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is off -->
-    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
-        <!-- Show a splash screen on the activity. Automatically removed when
-             the Flutter engine draws its first frame -->
+    <!-- Keep transparent system bars on API 29+ without OS contrast scrims. -->
+    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <item name="android:windowBackground">@drawable/launch_background</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
     </style>
-    <!-- Theme applied to the Android Window as soon as the process has started.
-         This theme determines the color of the Android Window while your
-         Flutter UI initializes, as well as behind your Flutter UI while its
-         running.
-
-         This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -5,6 +5,10 @@
         <!-- Show a splash screen on the activity. Automatically removed when
              the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your
@@ -14,5 +18,9 @@
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values-v29/styles.xml
+++ b/android/app/src/main/res/values-v29/styles.xml
@@ -1,26 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is off -->
+    <!-- Keep transparent system bars on API 29+ without OS contrast scrims. -->
     <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
-        <!-- Show a splash screen on the activity. Automatically removed when
-             the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
     </style>
-    <!-- Theme applied to the Android Window as soon as the process has started.
-         This theme determines the color of the Android Window while your
-         Flutter UI initializes, as well as behind your Flutter UI while its
-         running.
-
-         This Theme is only used starting with V2 of Flutter's Android embedding. -->
     <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
     </style>
 </resources>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -83,6 +83,8 @@
 	<string>Main</string>
 	<key>UIStatusBarHidden</key>
 	<false/>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,6 +39,7 @@ import 'notifications/in_app_notification_banner.dart';
 import 'notifications/notification_controller.dart';
 import 'notifications/push_device_registrar.dart';
 import 'platform/firebase_configuration.dart';
+import 'platform/system_ui.dart';
 import 'settings/app_icon_controller.dart';
 import 'settings/auto_download_media_controller.dart';
 import 'settings/blocked_user_service.dart';
@@ -96,6 +97,8 @@ Future<void> _bootstrapAndRunApp() async {
     DeviceOrientation.landscapeLeft,
     DeviceOrientation.landscapeRight,
   ]);
+  // Draw under transparent status / navigation bars (edge-to-edge).
+  configureImmersiveSystemUI();
   final prefs = await SharedPreferences.getInstance();
   KeywordBlocker.shared.initialize(prefs);
   CountryMessageFilter.shared.initialize(prefs);
@@ -382,15 +385,18 @@ class _MithkaAppState extends State<MithkaApp> with WidgetsBindingObserver {
                   ),
                 ],
               );
-              return _ScaledAppView(
-                fontScale: theme.fontScale,
-                interfaceScale: theme.interfaceScale,
-                child: DefaultTextStyle(
-                  style: theme.applyAppTextStyle(
-                    AppTextStyle.body(context.colors.textPrimary),
-                    boldText: media.boldText,
+              return AnnotatedRegion<SystemUiOverlayStyle>(
+                value: systemUiOverlayStyleFor(currentTheme.brightness),
+                child: _ScaledAppView(
+                  fontScale: theme.fontScale,
+                  interfaceScale: theme.interfaceScale,
+                  child: DefaultTextStyle(
+                    style: theme.applyAppTextStyle(
+                      AppTextStyle.body(context.colors.textPrimary),
+                      boldText: media.boldText,
+                    ),
+                    child: appChild,
                   ),
-                  child: appChild,
                 ),
               );
             },

--- a/lib/platform/system_ui.dart
+++ b/lib/platform/system_ui.dart
@@ -1,0 +1,54 @@
+//
+//  system_ui.dart
+//
+//  Edge-to-edge / immersive system bars for status bar and navigation bar.
+//
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Draw content under transparent system bars on Android and iOS.
+void configureImmersiveSystemUI() {
+  // Keep edge-to-edge even when Flutter's platform default changes.
+  SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+  SystemChrome.setSystemUIOverlayStyle(
+    systemUiOverlayStyleFor(Brightness.light),
+  );
+}
+
+/// Transparent bars with icons that contrast against [brightness] backgrounds.
+SystemUiOverlayStyle systemUiOverlayStyleFor(Brightness brightness) {
+  final light = brightness == Brightness.light;
+  return SystemUiOverlayStyle(
+    statusBarColor: Colors.transparent,
+    // iOS status bar text/icons.
+    statusBarBrightness: light ? Brightness.light : Brightness.dark,
+    // Android status bar icons.
+    statusBarIconBrightness: light ? Brightness.dark : Brightness.light,
+    systemNavigationBarColor: Colors.transparent,
+    systemNavigationBarDividerColor: Colors.transparent,
+    systemNavigationBarIconBrightness: light
+        ? Brightness.dark
+        : Brightness.light,
+    // Avoid OS painting opaque scrims over transparent bars.
+    systemStatusBarContrastEnforced: false,
+    systemNavigationBarContrastEnforced: false,
+  );
+}
+
+/// Convenience for tests and call sites that only have a [ThemeData].
+SystemUiOverlayStyle systemUiOverlayStyleForTheme(ThemeData theme) {
+  return systemUiOverlayStyleFor(theme.brightness);
+}
+
+/// Whether the current platform should treat system bars as edge-to-edge.
+bool get supportsImmersiveSystemUI {
+  switch (defaultTargetPlatform) {
+    case TargetPlatform.android:
+    case TargetPlatform.iOS:
+      return true;
+    default:
+      return false;
+  }
+}

--- a/test/system_ui_test.dart
+++ b/test/system_ui_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mithka/platform/system_ui.dart';
+
+void main() {
+  test('light theme uses dark system icons on transparent bars', () {
+    final style = systemUiOverlayStyleFor(Brightness.light);
+
+    expect(style.statusBarColor, Colors.transparent);
+    expect(style.systemNavigationBarColor, Colors.transparent);
+    expect(style.statusBarIconBrightness, Brightness.dark);
+    expect(style.systemNavigationBarIconBrightness, Brightness.dark);
+    expect(style.statusBarBrightness, Brightness.light);
+    expect(style.systemStatusBarContrastEnforced, isFalse);
+    expect(style.systemNavigationBarContrastEnforced, isFalse);
+  });
+
+  test('dark theme uses light system icons on transparent bars', () {
+    final style = systemUiOverlayStyleFor(Brightness.dark);
+
+    expect(style.statusBarColor, Colors.transparent);
+    expect(style.systemNavigationBarColor, Colors.transparent);
+    expect(style.statusBarIconBrightness, Brightness.light);
+    expect(style.systemNavigationBarIconBrightness, Brightness.light);
+    expect(style.statusBarBrightness, Brightness.dark);
+  });
+
+  test('theme helper follows ThemeData brightness', () {
+    final light = systemUiOverlayStyleForTheme(
+      ThemeData(brightness: Brightness.light),
+    );
+    final dark = systemUiOverlayStyleForTheme(
+      ThemeData(brightness: Brightness.dark),
+    );
+
+    expect(light.statusBarIconBrightness, Brightness.dark);
+    expect(dark.statusBarIconBrightness, Brightness.light);
+  });
+}


### PR DESCRIPTION
## Summary
- Enable immersive edge-to-edge drawing under transparent status and navigation bars on Android and iOS.
- Keep system bar icon contrast in sync with light/dark theme via `AnnotatedRegion` + shared `system_ui` helper.
- Android themes draw into display cutouts without opaque OS contrast scrims; `MainActivity` uses `WindowCompat.setDecorFitsSystemWindows(false)`.

Existing `SafeArea` / `MediaQuery` padding usage continues to keep tappable chrome clear of system insets.

## Test plan
- [x] `flutter test test/system_ui_test.dart`
- [x] `dart analyze lib/platform/system_ui.dart lib/main.dart`
- [ ] Android: verify transparent status + nav/gesture bar, content extends edge-to-edge, nav header and bottom tab not covered
- [ ] iOS: status bar icons follow theme; content respects top/bottom safe areas
- [ ] Toggle light/dark and confirm bar icon contrast flips correctly