### PR TITLE
fix: message bubble ownership wrong after account switch

### DIFF
--- a/lib/chat/channel_direct_messages_service.dart
+++ b/lib/chat/channel_direct_messages_service.dart
@@ -537,6 +537,7 @@ class ChannelDirectMessageTopicController extends ChangeNotifier {
   bool sending = false;
   bool hasOlder = true;
   String? error;
+  int? meId;
   String meName = '';
   TdFileRef? mePhoto;
 
@@ -552,6 +553,7 @@ class ChannelDirectMessageTopicController extends ChangeNotifier {
   Future<void> _loadMe() async {
     try {
       final me = await _client.query({'@type': 'getMe'});
+      meId = me.int64('id');
       meName = TDParse.userName(me);
       mePhoto = TDParse.smallPhoto(me.obj('profile_photo'));
       notifyListeners();

--- a/lib/chat/channel_direct_messages_view.dart
+++ b/lib/chat/channel_direct_messages_view.dart
@@ -509,6 +509,7 @@ class _ChannelDirectMessageTopicViewState
               isGroup: true,
               meName: _controller.meName,
               mePhoto: _controller.mePhoto,
+              meId: _controller.meId,
               forceShowTimestamp: true,
               onReply: (target) => setState(() => _replyTo = target),
             ),

--- a/lib/chat/chat_view.dart
+++ b/lib/chat/chat_view.dart
@@ -2466,6 +2466,7 @@ class _ChatViewState extends State<ChatView> {
       isGroup: _vm.isGroup,
       meName: _vm.meName,
       mePhoto: _vm.mePhoto,
+      meId: _vm.meId,
       showRepeat: _vm.canForwardContent && _isRepeatTail(messageIndex),
       onRepeat: () => _vm.repeatMessage(message),
       onLongPress: _isSelecting ? null : _showActionMenuForMessage,

--- a/lib/chat/message_bubble.dart
+++ b/lib/chat/message_bubble.dart
@@ -56,6 +56,7 @@ class MessageBubble extends StatefulWidget {
     required this.isGroup,
     this.meName = AppStringKeys.chatMeLabel,
     this.mePhoto,
+    this.meId,
     this.showRepeat = false,
     this.forceShowTimestamp = false,
     this.onRepeat,
@@ -100,6 +101,7 @@ class MessageBubble extends StatefulWidget {
   final bool isGroup;
   final String meName;
   final TdFileRef? mePhoto;
+  final int? meId;
   final bool showRepeat;
   final bool forceShowTimestamp;
   final VoidCallback? onRepeat;
@@ -325,7 +327,7 @@ class _MessageBubbleState extends State<MessageBubble>
             ),
             Transform.translate(
               offset: Offset(_swipeX, 0),
-              child: _row(message.isOutgoing),
+              child: _row(widget.meId != null ? message.senderId == widget.meId : message.isOutgoing),
             ),
           ],
         );

--- a/lib/chat/saved_messages_view.dart
+++ b/lib/chat/saved_messages_view.dart
@@ -52,6 +52,7 @@ class _SavedMessagesViewState extends State<SavedMessagesView> {
   bool _topicsExhausted = false;
   String _meName = '';
   TdFileRef? _mePhoto;
+  int? _meId;
 
   @override
   void initState() {
@@ -109,6 +110,7 @@ class _SavedMessagesViewState extends State<SavedMessagesView> {
       final me = await _service.currentUser();
       if (!mounted) return;
       setState(() {
+        _meId = me.int64('id');
         _meName = TDParse.userName(me);
         _mePhoto = TDParse.smallPhoto(me.obj('profile_photo'));
       });
@@ -701,6 +703,7 @@ class _SavedMessagesViewState extends State<SavedMessagesView> {
             isGroup: false,
             meName: _meName.isEmpty ? AppStringKeys.chatMeLabel : _meName,
             mePhoto: _mePhoto,
+            meId: _meId,
             forceShowTimestamp: true,
           ),
         ],


### PR DESCRIPTION
When switching accounts, cached message objects still carried the old account `is_outgoing` value. This caused messages sent by the previous account to appear on the right side (outgoing) layout with the new account avatar.

**Root cause**: `MessageBubble` relied on the cached `message.isOutgoing` flag from TDLib, which is not updated when the active account changes. The message list stays in memory across account switches.

**Fix**: Compare `message.senderId` with the current `meId` (from `getMe`) to determine outgoing status at render time, instead of using the cached `isOutgoing` value. This ensures the visual alignment and avatar always reflect the active account identity.

**Changes**:
- Added `meId` parameter to `MessageBubble` widget
- Updated `build` to use `message.senderId == meId` when `meId` is available, falling back to `message.isOutgoing`
- Updated `ChatViewModel`, `ChannelDirectMessageTopicController`, and `SavedMessagesView` to expose and pass `meId`