### PR TITLE
Fix chat open showing only a preview bubble until scroll.

### DIFF
--- a/lib/chat/chat_auto_scroll_policy.dart
+++ b/lib/chat/chat_auto_scroll_policy.dart
@@ -44,11 +44,16 @@ ChatInitialScrollPlan chatInitialScrollPlan({
   required bool hasCachedTranscript,
   required double? savedPixels,
   required bool savedAtBottom,
+  bool openAtBottom = false,
 }) {
   final finiteSavedPixels = savedPixels?.isFinite == true ? savedPixels! : 0.0;
+  // A cached latest window without a "was at bottom" snapshot still opens at
+  // the latest edge. Without a post-layout correction, center-keyed transcripts
+  // paint from offset zero and leave a one-bubble gap above empty space.
   return ChatInitialScrollPlan(
     initialOffset: hasCachedTranscript ? finiteSavedPixels : 0.0,
-    correctToBottomAfterLayout: hasCachedTranscript && savedAtBottom,
+    correctToBottomAfterLayout:
+        hasCachedTranscript && (savedAtBottom || openAtBottom),
   );
 }
 

--- a/lib/chat/chat_message_merge.dart
+++ b/lib/chat/chat_message_merge.dart
@@ -57,6 +57,23 @@ bool confirmsOlderHistoryExhausted({required bool onlyLocal}) {
   return !onlyLocal;
 }
 
+/// Chat-list preview / cold local cache often yields a single bubble. Windows
+/// thinner than this must await a remote page before the transcript is marked
+/// ready, otherwise the UI settles on the preview until the user scrolls.
+const kThinInitialHistoryMessageCount = 12;
+
+bool isThinInitialHistoryWindow(int messageCount) =>
+    messageCount > 0 && messageCount < kThinInitialHistoryMessageCount;
+
+/// Caught-up chats should open on the latest window. Around-last-read is only
+/// for chats that still have unread inbox messages.
+bool shouldLoadInitialHistoryAroundLastRead({
+  required bool openAtLatest,
+  required int lastReadInboxId,
+  required int unreadCount,
+}) =>
+    !openAtLatest && lastReadInboxId > 0 && unreadCount > 0;
+
 List<ChatMessage> mergeChatMessages(
   Iterable<ChatMessage> current,
   Iterable<ChatMessage> incoming, {

--- a/lib/chat/chat_view.dart
+++ b/lib/chat/chat_view.dart
@@ -827,6 +827,7 @@ class _ChatViewState extends State<ChatView> {
   bool _revealLoadedOlderPage = false;
   bool _loadedOlderRevealPending = false;
   bool _loadedOlderRevealScheduled = false;
+  bool _parkedShortTranscriptRepairScheduled = false;
   bool _wasLoadingOlder = false;
   bool _maintainSessionScrollAnchor = false;
   ChatThemeStyle? _resolvedChatThemeStyle;
@@ -890,15 +891,49 @@ class _ChatViewState extends State<ChatView> {
     _sessionScrollSnapshot = widget.initialMessageId == null
         ? _sessionScrollSnapshots[widget.chatId]
         : null;
+    final hasCachedLatestTranscript =
+        _sessionRenderState != null &&
+        !_sessionRenderState!.anchoredHistory &&
+        _sessionRenderState!.messages.isNotEmpty;
+    final openAtBottom = shouldOpenChatAtBottom(
+      hasExplicitTarget: widget.initialMessageId != null,
+      openAtLatest: _openAtLatest,
+      hasSnapshot: _sessionScrollSnapshot != null,
+      snapshotWasAtBottom: _sessionScrollSnapshot?.wasAtLoadedBottom ?? false,
+      hasCachedLatestTranscript: hasCachedLatestTranscript,
+    );
     final savedPivotMessageId = _sessionScrollSnapshot?.pivotMessageId;
-    if (savedPivotMessageId != null) {
-      _transcriptPivot = TranscriptPivot(savedPivotMessageId);
+    final hasSessionTranscript =
+        _sessionRenderState?.messages.isNotEmpty ?? false;
+    if (shouldRestoreTranscriptPivot(
+      pivotMessageId: savedPivotMessageId,
+      hasSessionTranscript: hasSessionTranscript,
+      newestMessageId: _latestServerMessage(
+        _sessionRenderState?.messages ?? const [],
+      )?.id,
+      openAtBottom: openAtBottom,
+    )) {
+      _transcriptPivot = TranscriptPivot(savedPivotMessageId!);
       _transcriptPivotFrozen = savedPivotMessageId != _pendingTranscriptOrderId;
+    } else if (savedPivotMessageId != null && !hasSessionTranscript) {
+      // Drop the orphan pivot from the in-memory snapshot so a later reopen
+      // with a fresh transcript cache does not reintroduce the thin after-arm.
+      final snapshot = _sessionScrollSnapshots[widget.chatId];
+      if (snapshot != null && snapshot.pivotMessageId != null) {
+        _sessionScrollSnapshots[widget.chatId] = _ChatScrollSnapshot(
+          pixels: snapshot.pixels,
+          wasAtLoadedBottom: snapshot.wasAtLoadedBottom,
+          pivotMessageId: null,
+          anchorMessageId: snapshot.anchorMessageId,
+          anchorViewportOffset: snapshot.anchorViewportOffset,
+        );
+      }
     }
     final initialScrollPlan = chatInitialScrollPlan(
       hasCachedTranscript: _sessionRenderState?.messages.isNotEmpty ?? false,
       savedPixels: _sessionScrollSnapshot?.pixels,
       savedAtBottom: _sessionScrollSnapshot?.wasAtLoadedBottom ?? false,
+      openAtBottom: openAtBottom,
     );
     _maintainRestoredBottom = initialScrollPlan.correctToBottomAfterLayout;
     final sessionScrollSnapshot = _sessionScrollSnapshot;
@@ -945,6 +980,12 @@ class _ChatViewState extends State<ChatView> {
       if (initialScrollPlan.correctToBottomAfterLayout) {
         _scheduleRestoredBottomCorrection();
       }
+      _scheduleShortTranscriptFill();
+      _scheduleParkedShortTranscriptRepair();
+    } else if (widget.seedMessage != null) {
+      _lastCount = _vm.messages.length;
+      _lastNewestMessageId = _latestServerMessage(_vm.messages)?.id;
+      _lastOldestMessageId = _oldestServerMessage(_vm.messages)?.id;
     }
     _vm.addListener(_onModel);
     _setScrollTarget(widget.initialMessageId);
@@ -1125,6 +1166,7 @@ class _ChatViewState extends State<ChatView> {
     _transcriptPointersDown.remove(event.pointer);
     _scheduleLoadedOlderReveal();
     _scheduleShortFirstContactReveal();
+    _scheduleShortTranscriptFill();
     _scheduleSessionScrollAnchorMaintenance();
     _scheduleRestoredBottomCorrection();
   }
@@ -1136,7 +1178,14 @@ class _ChatViewState extends State<ChatView> {
     _showingFullyVisibleFirstContactHistory = false;
     _maintainSessionScrollAnchor = false;
     _maintainRestoredBottom = false;
-    _transcriptPivotFrozen = true;
+    // Do not freeze a thin after-center arm: that parks older history above the
+    // center while the open animation / first touch is still settling.
+    if (shouldFreezeTranscriptPivot(
+      latestArmIsShort: _isTranscriptShort(),
+      canLoadOlder: _vm.canLoadOlder,
+    )) {
+      _transcriptPivotFrozen = true;
+    }
   }
 
   void _stopActiveTranscriptScroll() {
@@ -1626,6 +1675,25 @@ class _ChatViewState extends State<ChatView> {
       historyFillInFlight: _isFillingShortTranscript || _loadingOlderFromScroll,
       revealRequested: _revealLoadedOlderPage,
     );
+    final followingLatest =
+        !_autoScrollPolicy.preservesViewport && !_maintainSessionScrollAnchor;
+    final hasMessageOlderThanPivot = _transcriptPivot != null &&
+        _vm.messages.any(
+          (message) =>
+              _transcriptOrderId(message) < _transcriptPivot!.cutoffMessageId,
+        );
+    final expandedInitialWindow = shouldRebaseForExpandedInitialWindow(
+      transcriptChanged: !identical(_transcriptCacheMessages, _vm.messages),
+      latestArmIsShort: _isTranscriptShort(),
+      hasMessageOlderThanPivot: hasMessageOlderThanPivot,
+      followingLatest: followingLatest,
+    );
+    final parkedShortArm = shouldRebaseParkedShortTranscriptPivot(
+      pivotCutoffMessageId: _transcriptPivot?.cutoffMessageId,
+      latestArmIsShort: _isTranscriptShort(),
+      hasMessageOlderThanPivot: hasMessageOlderThanPivot,
+      followingLatest: followingLatest,
+    );
     final wasPinnedToLoadedBottom =
         _didInitialScroll &&
         !_hasTranscriptPointerDown &&
@@ -1671,15 +1739,21 @@ class _ChatViewState extends State<ChatView> {
     )) {
       _resetTranscriptPivot();
     }
-    if (hydratedShortTranscript ||
+    final shouldResetParkedPivot =
+        parkedShortArm ||
+        expandedInitialWindow ||
+        hydratedShortTranscript ||
         (!_transcriptPivotFrozen &&
             _vm.initialLoaded &&
-            !identical(_transcriptCacheMessages, _vm.messages))) {
+            !identical(_transcriptCacheMessages, _vm.messages));
+    if (shouldResetParkedPivot) {
       // Cold local pages may be followed by a larger remote hydration. Until
       // the latest arm fills a viewport (or the user scrolls), let that fuller
-      // initial window establish the fixed cutoff.
+      // initial window establish the fixed cutoff. Also unpark a frozen newest
+      // pivot that already has older messages sitting in before-center.
       _resetTranscriptPivot();
     }
+    final rebasedParkedShortArm = parkedShortArm || expandedInitialWindow;
     final liveIncomingMessageIds = _vm.consumeLiveIncomingMessageIds();
     if (_vm.messages.length != _lastCount) {
       final wasNearBottom = _isNearBottom(72);
@@ -1768,13 +1842,15 @@ class _ChatViewState extends State<ChatView> {
         if (mounted) setState(() => _bannerDismissed = true);
       });
     }
-    if (wasPinnedToLoadedBottom && !_bottomScrollScheduled) {
+    if ((wasPinnedToLoadedBottom || rebasedParkedShortArm) &&
+        !_bottomScrollScheduled) {
       _scheduleScrollToBottom(animated: false);
     }
     setState(() {});
     _cacheCurrentTranscript();
     _scheduleSessionScrollAnchorMaintenance();
     _scheduleRestoredBottomCorrection();
+    _scheduleParkedShortTranscriptRepair();
   }
 
   void _setScrollTarget(int? messageId) {
@@ -1845,6 +1921,11 @@ class _ChatViewState extends State<ChatView> {
       await _restoreSessionScrollPosition();
     } else {
       await _positionInitialTranscript();
+    }
+    if (!mounted) return;
+    if (_repairParkedShortTranscriptPivot()) {
+      await WidgetsBinding.instance.endOfFrame;
+      if (mounted && _scroll.hasClients) _scrollToBottom();
     }
     if (!mounted) return;
     setState(() => _initialTranscriptReady = true);
@@ -2191,19 +2272,80 @@ class _ChatViewState extends State<ChatView> {
     });
   }
 
+  void _scheduleParkedShortTranscriptRepair() {
+    if (_parkedShortTranscriptRepairScheduled) return;
+    _parkedShortTranscriptRepairScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _parkedShortTranscriptRepairScheduled = false;
+      if (!mounted) return;
+      if (!_repairParkedShortTranscriptPivot()) return;
+      setState(() {});
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _scroll.hasClients) _scrollToBottom();
+      });
+    });
+  }
+
+  /// Unparks a frozen newest (or newest-like) pivot when older messages are
+  /// already in the model but only the after-center arm is visible.
+  bool _repairParkedShortTranscriptPivot() {
+    if (!mounted ||
+        (_vm.anchoredHistory && !_isTranscriptShort()) ||
+        _maintainSessionScrollAnchor ||
+        _autoScrollPolicy.preservesViewport ||
+        _scrollTargetId != null) {
+      return false;
+    }
+    final pivot = _transcriptPivot;
+    if (pivot == null) return false;
+    final hasOlder = _vm.messages.any(
+      (message) => _transcriptOrderId(message) < pivot.cutoffMessageId,
+    );
+    if (!shouldRebaseParkedShortTranscriptPivot(
+      pivotCutoffMessageId: pivot.cutoffMessageId,
+      latestArmIsShort: _isTranscriptShort(),
+      hasMessageOlderThanPivot: hasOlder,
+      followingLatest: true,
+    )) {
+      return false;
+    }
+    _resetTranscriptPivot();
+    _transcriptCache = null;
+    _transcriptCacheMessages = null;
+    return true;
+  }
+
   Future<void> _fillShortTranscript() async {
+    if (!mounted || !_scroll.hasClients || !_vm.initialLoaded) return;
+    // Repair does not need another network page: history may already sit in
+    // before-center under a frozen pivot.
+    if (_repairParkedShortTranscriptPivot()) {
+      setState(() {});
+      await WidgetsBinding.instance.endOfFrame;
+      if (mounted && _scroll.hasClients) _scrollToBottom();
+    }
     if (!mounted ||
         !_scroll.hasClients ||
-        !_vm.initialLoaded ||
-        _vm.anchoredHistory ||
+        (_vm.anchoredHistory && !_isTranscriptShort()) ||
         _maintainSessionScrollAnchor ||
-        _transcriptPivotFrozen ||
         _autoScrollPolicy.preservesViewport ||
         _scrollTargetId != null ||
         !_vm.canLoadOlder) {
       return;
     }
     if (!_isTranscriptShort()) return;
+    // A restored or touch-claimed freeze on a thin arm must not block fill;
+    // otherwise older pages stay in the before-center sliver forever.
+    if (_transcriptPivotFrozen) {
+      if (!shouldFreezeTranscriptPivot(
+        latestArmIsShort: true,
+        canLoadOlder: _vm.canLoadOlder,
+      )) {
+        _transcriptPivotFrozen = false;
+      } else {
+        return;
+      }
+    }
 
     final generation = ++_shortTranscriptFillGeneration;
     _isFillingShortTranscript = true;
@@ -2227,6 +2369,14 @@ class _ChatViewState extends State<ChatView> {
       _isFillingShortTranscript = false;
     }
     if (!_vm.hasOlderHistory) _olderHistoryExhaustedHint = true;
+    if (_repairParkedShortTranscriptPivot()) {
+      setState(() {});
+      await WidgetsBinding.instance.endOfFrame;
+      if (mounted && _scroll.hasClients) {
+        _scrollToBottom();
+        return;
+      }
+    }
     if (_canContinueShortTranscriptFill(generation)) {
       if (loadedAny) _positionAfterShortFill();
       // An empty older page flips canLoadOlder without a model notification.
@@ -2243,11 +2393,11 @@ class _ChatViewState extends State<ChatView> {
         generation == _shortTranscriptFillGeneration &&
         _scroll.hasClients &&
         !_hasTranscriptPointerDown &&
-        !_vm.anchoredHistory &&
+        !(_vm.anchoredHistory && !_isTranscriptShort()) &&
         !_maintainSessionScrollAnchor &&
-        !_transcriptPivotFrozen &&
         !_autoScrollPolicy.preservesViewport &&
-        _scrollTargetId == null;
+        _scrollTargetId == null &&
+        (!_transcriptPivotFrozen || _isTranscriptShort());
   }
 
   bool _isTranscriptShort() {
@@ -2255,7 +2405,27 @@ class _ChatViewState extends State<ChatView> {
     // With a center sliver, only the after-center arm defines the latest edge.
     // A large negative min extent says nothing about whether that arm fills
     // the viewport.
-    return _scroll.position.maxScrollExtent <= 24;
+    return isLatestTranscriptArmShort(
+      maxScrollExtent: _scroll.position.maxScrollExtent,
+      afterCenterEntryCount: _latestArmEntryCount(),
+    );
+  }
+
+  int _latestArmEntryCount() {
+    final entries = _transcriptCache;
+    if (entries == null || entries.isEmpty) {
+      return _vm.messages.isEmpty ? 0 : _vm.messages.length;
+    }
+    final pivot = _transcriptPivot;
+    if (pivot == null) return entries.length;
+    var count = 0;
+    for (final entry in entries) {
+      final belongsToLatestArm = entry.messages.any(
+        (message) => _transcriptOrderId(message) >= pivot.cutoffMessageId,
+      );
+      if (belongsToLatestArm) count++;
+    }
+    return count;
   }
 
   void _positionAfterShortFill() {
@@ -6090,7 +6260,10 @@ class _ChatViewState extends State<ChatView> {
         _scheduleTranscriptPivotFreeze();
         return;
       }
-      if (!_isTranscriptShort() || !_vm.canLoadOlder) {
+      if (shouldFreezeTranscriptPivot(
+        latestArmIsShort: _isTranscriptShort(),
+        canLoadOlder: _vm.canLoadOlder,
+      )) {
         _transcriptPivotFrozen = true;
       }
     });

--- a/lib/chat/chat_view_model.dart
+++ b/lib/chat/chat_view_model.dart
@@ -3040,9 +3040,16 @@ class ChatViewModel extends ChangeNotifier {
   // MARK: - History
 
   Future<void> _loadInitialHistory({required bool openAtLatest}) async {
-    if (!openAtLatest && lastReadInboxId > 0) {
+    if (shouldLoadInitialHistoryAroundLastRead(
+      openAtLatest: openAtLatest,
+      lastReadInboxId: lastReadInboxId,
+      unreadCount: unreadCount,
+    )) {
       final loaded = await _loadInitialAroundLastRead();
-      if (loaded) return;
+      // A chat-list preview hit can satisfy around-last-read with one local
+      // bubble. Fall through to latest hydration so the open path does not
+      // settle until the user scrolls.
+      if (loaded && !isThinInitialHistoryWindow(messages.length)) return;
     }
     await _loadInitialLatestHistory();
   }
@@ -3053,6 +3060,13 @@ class ChatViewModel extends ChangeNotifier {
       onlyLocal: true,
     );
     if (loadedLocal) {
+      if (isThinInitialHistoryWindow(messages.length)) {
+        return loadAroundMessage(
+          lastReadInboxId,
+          scrollToTarget: false,
+          replaceCurrentWindow: false,
+        );
+      }
       unawaited(
         loadAroundMessage(
           lastReadInboxId,
@@ -3066,8 +3080,13 @@ class ChatViewModel extends ChangeNotifier {
   }
 
   Future<void> _loadInitialLatestHistory() async {
+    anchoredHistory = false;
     final localLoaded = await _fetchHistory(0, 0, 40, onlyLocal: true);
     if (!localLoaded) {
+      await _fetchHistory(0, 0, 40);
+    } else if (isThinInitialHistoryWindow(messages.length)) {
+      // Await the remote page for preview-sized local caches. Fire-and-forget
+      // left the UI on a single bubble until a scroll triggered loadOlder.
       await _fetchHistory(0, 0, 40);
     } else {
       unawaited(_fetchHistory(0, 0, 40));
@@ -3076,8 +3095,8 @@ class ChatViewModel extends ChangeNotifier {
     // Render the first page immediately. Older unread-boundary paging used to
     // happen here and could block a large media channel for seconds on cold
     // cache before any UI appeared.
-    if (messages.length < 12) {
-      unawaited(_fetchHistory(_allMessages.first.id, 0, 40));
+    if (isThinInitialHistoryWindow(messages.length)) {
+      await _fetchHistory(_allMessages.first.id, 0, 40);
     }
   }
 

--- a/lib/chat/transcript_pivot_partition.dart
+++ b/lib/chat/transcript_pivot_partition.dart
@@ -48,6 +48,92 @@ bool shouldRebaseForHydratedOlderPage({
     latestArmWasShort &&
     (historyFillInFlight || revealRequested);
 
+/// Whether the after-center arm is still too thin to treat as a filled
+/// transcript.
+///
+/// [maxScrollExtent] alone is not enough: a single tall media bubble can push
+/// extent past [extentThreshold] while older history remains off-screen in the
+/// before-center sliver. A low [afterCenterEntryCount] keeps short-fill and
+/// pivot rebase alive in that case.
+bool isLatestTranscriptArmShort({
+  required double maxScrollExtent,
+  required int afterCenterEntryCount,
+  double extentThreshold = 24,
+  int entryThreshold = 3,
+}) {
+  if (afterCenterEntryCount < entryThreshold) return true;
+  return maxScrollExtent <= extentThreshold;
+}
+
+/// Freeze only once the latest arm fills the viewport (or older history is
+/// exhausted). Freezing a one-message after-center arm parks older pages above
+/// the center forever.
+bool shouldFreezeTranscriptPivot({
+  required bool latestArmIsShort,
+  required bool canLoadOlder,
+}) => !latestArmIsShort || !canLoadOlder;
+
+/// A restored pivot pinned to the newest known message leaves only that
+/// bubble in the after-center arm. When reopening at the latest edge, discard
+/// it so short-fill can rebuild a fuller cutoff.
+bool shouldDiscardRestoredTranscriptPivot({
+  required int? pivotMessageId,
+  required int? newestMessageId,
+  required bool openAtBottom,
+}) =>
+    openAtBottom &&
+    pivotMessageId != null &&
+    newestMessageId != null &&
+    pivotMessageId == newestMessageId;
+
+/// Whether a scroll-snapshot pivot may be applied when opening a chat.
+///
+/// Orphan snapshots (pivot without a matching session transcript) must not be
+/// restored: the view-model then starts from a single seed message, freezes the
+/// newest cutoff, and parks every later hydrate in the before-center sliver.
+bool shouldRestoreTranscriptPivot({
+  required int? pivotMessageId,
+  required bool hasSessionTranscript,
+  required int? newestMessageId,
+  required bool openAtBottom,
+}) {
+  if (pivotMessageId == null || !hasSessionTranscript) return false;
+  return !shouldDiscardRestoredTranscriptPivot(
+    pivotMessageId: pivotMessageId,
+    newestMessageId: newestMessageId,
+    openAtBottom: openAtBottom,
+  );
+}
+
+/// Force a pivot reset when the after-center arm is thin but older messages
+/// are already present below the cutoff.
+///
+/// This is the open-chat failure mode where history is loaded yet invisible
+/// until the user scrolls toward [ScrollPosition.minScrollExtent]. It must not
+/// wait for another network page: `loadOlder` may already be exhausted.
+bool shouldRebaseParkedShortTranscriptPivot({
+  required int? pivotCutoffMessageId,
+  required bool latestArmIsShort,
+  required bool hasMessageOlderThanPivot,
+  required bool followingLatest,
+}) {
+  if (!followingLatest || pivotCutoffMessageId == null) return false;
+  return latestArmIsShort && hasMessageOlderThanPivot;
+}
+
+/// First window expansion after a seed/restored pivot: message identity changed
+/// while the latest arm is still short and older IDs already exist.
+bool shouldRebaseForExpandedInitialWindow({
+  required bool transcriptChanged,
+  required bool latestArmIsShort,
+  required bool hasMessageOlderThanPivot,
+  required bool followingLatest,
+}) =>
+    transcriptChanged &&
+    latestArmIsShort &&
+    hasMessageOlderThanPivot &&
+    followingLatest;
+
 /// Keeps the first-contact card at the absolute start of non-empty history.
 ///
 /// An empty centered transcript is the only exception: placing the card after

--- a/test/chat_message_merge_test.dart
+++ b/test/chat_message_merge_test.dart
@@ -156,4 +156,38 @@ void main() {
     expect(confirmsOlderHistoryExhausted(onlyLocal: false), isTrue);
     expect(confirmsOlderHistoryExhausted(onlyLocal: false), isTrue);
   });
+
+  test('caught-up chats skip around-last-read on open', () {
+    expect(
+      shouldLoadInitialHistoryAroundLastRead(
+        openAtLatest: false,
+        lastReadInboxId: 900,
+        unreadCount: 0,
+      ),
+      isFalse,
+    );
+    expect(
+      shouldLoadInitialHistoryAroundLastRead(
+        openAtLatest: false,
+        lastReadInboxId: 900,
+        unreadCount: 3,
+      ),
+      isTrue,
+    );
+    expect(
+      shouldLoadInitialHistoryAroundLastRead(
+        openAtLatest: true,
+        lastReadInboxId: 900,
+        unreadCount: 3,
+      ),
+      isFalse,
+    );
+  });
+
+  test('preview-sized windows are treated as thin initial history', () {
+    expect(isThinInitialHistoryWindow(1), isTrue);
+    expect(isThinInitialHistoryWindow(11), isTrue);
+    expect(isThinInitialHistoryWindow(12), isFalse);
+    expect(isThinInitialHistoryWindow(0), isFalse);
+  });
 }

--- a/test/chat_session_scroll_restore_test.dart
+++ b/test/chat_session_scroll_restore_test.dart
@@ -223,6 +223,44 @@ void main() {
       );
     });
 
+    test(
+      'cached transcript without snapshot still corrects to bottom when opening at bottom',
+      () {
+        final plan = chatInitialScrollPlan(
+          hasCachedTranscript: true,
+          savedPixels: null,
+          savedAtBottom: false,
+          openAtBottom: true,
+        );
+
+        expect(plan.initialOffset, 0);
+        expect(plan.correctToBottomAfterLayout, isTrue);
+      },
+    );
+
+    test('cached scrolled-up snapshot does not force a bottom correction', () {
+      final plan = chatInitialScrollPlan(
+        hasCachedTranscript: true,
+        savedPixels: 640,
+        savedAtBottom: false,
+        openAtBottom: false,
+      );
+
+      expect(plan.initialOffset, 640);
+      expect(plan.correctToBottomAfterLayout, isFalse);
+    });
+
+    test('openAtBottom alone is enough to correct a cached bottom reopen', () {
+      final plan = chatInitialScrollPlan(
+        hasCachedTranscript: true,
+        savedPixels: 0,
+        savedAtBottom: false,
+        openAtBottom: true,
+      );
+
+      expect(plan.correctToBottomAfterLayout, isTrue);
+    });
+
     test('restores the anchor to the same viewport y position', () {
       expect(
         correctedChatSessionScrollOffset(

--- a/test/transcript_pivot_partition_test.dart
+++ b/test/transcript_pivot_partition_test.dart
@@ -133,6 +133,207 @@ void main() {
     });
   });
 
+  group('isLatestTranscriptArmShort', () {
+    test('treats a tall single bubble as short when the arm has few entries', () {
+      expect(
+        isLatestTranscriptArmShort(
+          maxScrollExtent: 400,
+          afterCenterEntryCount: 1,
+        ),
+        isTrue,
+      );
+    });
+
+    test('treats a low max extent as short even with several entries', () {
+      expect(
+        isLatestTranscriptArmShort(
+          maxScrollExtent: 12,
+          afterCenterEntryCount: 5,
+        ),
+        isTrue,
+      );
+    });
+
+    test('treats a filled multi-entry arm as complete', () {
+      expect(
+        isLatestTranscriptArmShort(
+          maxScrollExtent: 800,
+          afterCenterEntryCount: 8,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('shouldFreezeTranscriptPivot', () {
+    test('refuses to freeze while older history can still fill a short arm', () {
+      expect(
+        shouldFreezeTranscriptPivot(
+          latestArmIsShort: true,
+          canLoadOlder: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('freezes once the latest arm is full', () {
+      expect(
+        shouldFreezeTranscriptPivot(
+          latestArmIsShort: false,
+          canLoadOlder: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('freezes when older history is exhausted', () {
+      expect(
+        shouldFreezeTranscriptPivot(
+          latestArmIsShort: true,
+          canLoadOlder: false,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('shouldDiscardRestoredTranscriptPivot', () {
+    test('discards a newest-only pivot when reopening at the bottom', () {
+      expect(
+        shouldDiscardRestoredTranscriptPivot(
+          pivotMessageId: 900,
+          newestMessageId: 900,
+          openAtBottom: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('keeps a newest pivot when restoring a scrolled-up viewport', () {
+      expect(
+        shouldDiscardRestoredTranscriptPivot(
+          pivotMessageId: 900,
+          newestMessageId: 900,
+          openAtBottom: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('keeps an older cutoff when reopening at the bottom', () {
+      expect(
+        shouldDiscardRestoredTranscriptPivot(
+          pivotMessageId: 100,
+          newestMessageId: 900,
+          openAtBottom: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('shouldRestoreTranscriptPivot', () {
+    test('refuses orphan pivots without a session transcript', () {
+      expect(
+        shouldRestoreTranscriptPivot(
+          pivotMessageId: 900,
+          hasSessionTranscript: false,
+          newestMessageId: null,
+          openAtBottom: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('refuses a newest pivot when opening at the bottom', () {
+      expect(
+        shouldRestoreTranscriptPivot(
+          pivotMessageId: 900,
+          hasSessionTranscript: true,
+          newestMessageId: 900,
+          openAtBottom: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('keeps an older pivot with a matching session transcript', () {
+      expect(
+        shouldRestoreTranscriptPivot(
+          pivotMessageId: 100,
+          hasSessionTranscript: true,
+          newestMessageId: 900,
+          openAtBottom: true,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('shouldRebaseParkedShortTranscriptPivot', () {
+    test('rebases a thin after-arm that already has older messages', () {
+      expect(
+        shouldRebaseParkedShortTranscriptPivot(
+          pivotCutoffMessageId: 900,
+          latestArmIsShort: true,
+          hasMessageOlderThanPivot: true,
+          followingLatest: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('keeps the pivot while the user preserves a scrolled-up viewport', () {
+      expect(
+        shouldRebaseParkedShortTranscriptPivot(
+          pivotCutoffMessageId: 900,
+          latestArmIsShort: true,
+          hasMessageOlderThanPivot: true,
+          followingLatest: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('keeps the pivot when the latest arm already fills the viewport', () {
+      expect(
+        shouldRebaseParkedShortTranscriptPivot(
+          pivotCutoffMessageId: 100,
+          latestArmIsShort: false,
+          hasMessageOlderThanPivot: true,
+          followingLatest: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('shouldRebaseForExpandedInitialWindow', () {
+    test('rebases when hydration grows past a short frozen cutoff', () {
+      expect(
+        shouldRebaseForExpandedInitialWindow(
+          transcriptChanged: true,
+          latestArmIsShort: true,
+          hasMessageOlderThanPivot: true,
+          followingLatest: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('ignores identical transcripts', () {
+      expect(
+        shouldRebaseForExpandedInitialWindow(
+          transcriptChanged: false,
+          latestArmIsShort: true,
+          hasMessageOlderThanPivot: true,
+          followingLatest: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('shouldPlaceFirstContactCardAtCenter', () {
     test('uses center only for a completely empty transcript', () {
       expect(


### PR DESCRIPTION
Rebase parked thin after-center pivots, avoid restoring orphan newest cutoffs, and wait on thin local windows so history hydrates into the visible transcript without a swipe.