### PR TITLE
fix: forum topic bot messages not showing + service message recognition

### DIFF
--- a/lib/channels/topic_channels_view.dart
+++ b/lib/channels/topic_channels_view.dart
@@ -327,7 +327,9 @@ class _TopicChannelsViewState extends State<TopicChannelsView> {
               .toList()
             ..sort((a, b) => b.date.compareTo(a.date));
       final roots = messages
-          .where((message) => message.replyToMessageId == null)
+          .where((message) =>
+              message.replyToMessageId == null ||
+              message.replyToMessageId == threadId)
           .toList();
       if (roots.isNotEmpty) return roots;
       if (messages.isNotEmpty) return messages;

--- a/lib/channels/topic_chat_view.dart
+++ b/lib/channels/topic_chat_view.dart
@@ -336,9 +336,10 @@ class _TopicChatViewState extends State<TopicChatView> {
         final info = topic.obj('info') ?? topic;
         final last = topic.obj('last_message');
         final message = last == null ? null : TDParse.message(last);
-        if (message?.isService == true) continue;
         final id = _topicId(topic, info) ?? message?.id;
         if (id == null || id == 0) continue;
+        final isServiceLast = message?.isService == true;
+        final fallbackDate = last?.integer('date');
         next.add(
           _ForumTopic(
             id: id,
@@ -346,7 +347,13 @@ class _TopicChatViewState extends State<TopicChatView> {
                 info.str('name') ??
                 topic.str('name') ??
                 AppStringKeys.topicChatTopicTitle,
-            lastMessage: message ?? _fallbackTopicMessage(id, info, topic),
+            lastMessage: message ??
+                _fallbackTopicMessage(
+                  id,
+                  info,
+                  topic,
+                  fallbackDate: fallbackDate,
+                ),
             isPinned: topic.boolean('is_pinned') ?? false,
             isMuted:
                 (topic.obj('notification_settings')?.integer('mute_for') ?? 0) >
@@ -354,7 +361,7 @@ class _TopicChatViewState extends State<TopicChatView> {
             unreadCount: _topicUnreadCount(topic, info),
             iconCustomEmojiId: _topicCustomEmojiId(topic, info),
             iconColor: _topicIconColor(topic, info),
-            lastMessageIsSynthetic: message == null,
+            lastMessageIsSynthetic: message == null || isServiceLast,
           ),
         );
       }
@@ -401,7 +408,9 @@ class _TopicChatViewState extends State<TopicChatView> {
               .map(TDParse.message)
               .whereType<ChatMessage>()
               .where((message) => !message.isService)
-              .where((message) => message.replyToMessageId == null)
+              .where((message) =>
+                  message.replyToMessageId == null ||
+                  message.replyToMessageId == topic.id)
               .toList()
             ..sort((a, b) => b.date.compareTo(a.date));
       _topicMessages[topic.id] = messages.isEmpty
@@ -466,8 +475,9 @@ class _TopicChatViewState extends State<TopicChatView> {
   ChatMessage _fallbackTopicMessage(
     int id,
     Map<String, dynamic> info,
-    Map<String, dynamic> topic,
-  ) {
+    Map<String, dynamic> topic, {
+    int? fallbackDate,
+  }) {
     final created =
         info.integer('creation_date') ?? topic.integer('creation_date') ?? 0;
     return ChatMessage(
@@ -476,7 +486,7 @@ class _TopicChatViewState extends State<TopicChatView> {
           info.str('name') ??
           topic.str('name') ??
           AppStrings.t(AppStringKeys.topicChatTopicTitle),
-      date: created,
+      date: fallbackDate ?? created,
       isOutgoing: false,
       chatId: widget.chat.id,
     );

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1528,6 +1528,10 @@ abstract final class AppStringKeys {
       'groupManagementLogChangedSlowMode';
   static const groupManagementLogCreatedTopic =
       'groupManagementLogCreatedTopic';
+  static const groupManagementLogClosedTopic =
+      'groupManagementLogClosedTopic';
+  static const groupManagementLogReopenedTopic =
+      'groupManagementLogReopenedTopic';
   static const groupManagementLogDeletedInviteLink =
       'groupManagementLogDeletedInviteLink';
   static const groupManagementLogDeletedMessage =

--- a/lib/l10n/messages/de.dart
+++ b/lib/l10n/messages/de.dart
@@ -1175,6 +1175,8 @@ const deMessages = <String, String>{
       "Öffentlichen Benutzernamen geändert",
   'groupManagementLogChangedSlowMode': "Langsamen Modus geändert",
   'groupManagementLogCreatedTopic': "Thema erstellt",
+  'groupManagementLogClosedTopic': "Thema geschlossen",
+  'groupManagementLogReopenedTopic': "Thema wieder geöffnet",
   'groupManagementLogDeletedInviteLink': "Einladungslink gelöscht",
   'groupManagementLogDeletedMessage': "Nachricht gelöscht",
   'groupManagementLogDeletedTopic': "Thema gelöscht",

--- a/lib/l10n/messages/en.dart
+++ b/lib/l10n/messages/en.dart
@@ -1196,6 +1196,8 @@ const enMessages = <String, String>{
   'groupManagementLogChangedPublicUsername': "Changed public username",
   'groupManagementLogChangedSlowMode': "Changed slow mode",
   'groupManagementLogCreatedTopic': "Created topic",
+  'groupManagementLogClosedTopic': "Closed topic",
+  'groupManagementLogReopenedTopic': "Reopened topic",
   'groupManagementLogDeletedInviteLink': "Deleted invite link",
   'groupManagementLogDeletedMessage': "Deleted message",
   'groupManagementLogDeletedTopic': "Deleted topic",

--- a/lib/l10n/messages/es.dart
+++ b/lib/l10n/messages/es.dart
@@ -1162,6 +1162,8 @@ const esMessages = <String, String>{
       "Cambió el nombre de usuario público",
   'groupManagementLogChangedSlowMode': "Cambió el modo lento",
   'groupManagementLogCreatedTopic': "Creó un tema",
+  'groupManagementLogClosedTopic': "Cerró el tema",
+  'groupManagementLogReopenedTopic': "Reabrió el tema",
   'groupManagementLogDeletedInviteLink': "Eliminó un enlace de invitación",
   'groupManagementLogDeletedMessage': "Eliminó un mensaje",
   'groupManagementLogDeletedTopic': "Eliminó un tema",

--- a/lib/l10n/messages/fr.dart
+++ b/lib/l10n/messages/fr.dart
@@ -1173,6 +1173,8 @@ const frMessages = <String, String>{
       "A modifié le nom d’utilisateur public",
   'groupManagementLogChangedSlowMode': "A modifié le mode lent",
   'groupManagementLogCreatedTopic': "A créé un sujet",
+  'groupManagementLogClosedTopic': "A fermé le sujet",
+  'groupManagementLogReopenedTopic': "A rouvert le sujet",
   'groupManagementLogDeletedInviteLink': "A supprimé un lien d’invitation",
   'groupManagementLogDeletedMessage': "A supprimé un message",
   'groupManagementLogDeletedTopic': "A supprimé un sujet",

--- a/lib/l10n/messages/ja.dart
+++ b/lib/l10n/messages/ja.dart
@@ -1072,6 +1072,8 @@ const jaMessages = <String, String>{
   'groupManagementLogChangedPublicUsername': "公開ユーザー名を変更しました",
   'groupManagementLogChangedSlowMode': "スローモードを変更しました",
   'groupManagementLogCreatedTopic': "トピックを作成しました",
+  'groupManagementLogClosedTopic': "トピックを閉じました",
+  'groupManagementLogReopenedTopic': "トピックを再開しました",
   'groupManagementLogDeletedInviteLink': "招待リンクを削除しました",
   'groupManagementLogDeletedMessage': "メッセージを削除しました",
   'groupManagementLogDeletedTopic': "トピックを削除しました",

--- a/lib/l10n/messages/ko.dart
+++ b/lib/l10n/messages/ko.dart
@@ -1074,6 +1074,8 @@ const koMessages = <String, String>{
   'groupManagementLogChangedPublicUsername': "공개 사용자 이름을 변경했습니다",
   'groupManagementLogChangedSlowMode': "슬로우 모드를 변경했습니다",
   'groupManagementLogCreatedTopic': "주제를 만들었습니다",
+  'groupManagementLogClosedTopic': "주제를 닫았습니다",
+  'groupManagementLogReopenedTopic': "주제를 다시 열었습니다",
   'groupManagementLogDeletedInviteLink': "초대 링크를 삭제했습니다",
   'groupManagementLogDeletedMessage': "메시지를 삭제했습니다",
   'groupManagementLogDeletedTopic': "주제를 삭제했습니다",

--- a/lib/l10n/messages/zh_hans.dart
+++ b/lib/l10n/messages/zh_hans.dart
@@ -1048,6 +1048,8 @@ const zhHansMessages = <String, String>{
   'groupManagementLogChangedPublicUsername': "修改了公开用户名",
   'groupManagementLogChangedSlowMode': "修改了慢速模式",
   'groupManagementLogCreatedTopic': "创建了话题",
+  'groupManagementLogClosedTopic': "关闭了话题",
+  'groupManagementLogReopenedTopic': "重新打开了话题",
   'groupManagementLogDeletedInviteLink': "删除了邀请链接",
   'groupManagementLogDeletedMessage': "删除了消息",
   'groupManagementLogDeletedTopic': "删除了话题",

--- a/lib/l10n/messages/zh_hant.dart
+++ b/lib/l10n/messages/zh_hant.dart
@@ -1050,6 +1050,8 @@ const zhHantMessages = <String, String>{
   'groupManagementLogChangedPublicUsername': "修改了公開使用者名稱",
   'groupManagementLogChangedSlowMode': "修改了慢速模式",
   'groupManagementLogCreatedTopic': "建立了話題",
+  'groupManagementLogClosedTopic': "關閉了話題",
+  'groupManagementLogReopenedTopic': "重新開啟了話題",
   'groupManagementLogDeletedInviteLink': "刪除了邀請連結",
   'groupManagementLogDeletedMessage': "刪除了訊息",
   'groupManagementLogDeletedTopic': "刪除了話題",

--- a/lib/tdlib/td_models.dart
+++ b/lib/tdlib/td_models.dart
@@ -3659,6 +3659,8 @@ abstract final class TDParse {
     'messageVideoChatStarted',
     'messageVideoChatEnded',
     'messageForumTopicCreated',
+    'messageForumTopicEdited',
+    'messageForumTopicIsClosedToggled',
     'messageChatBoost',
     'messageChatAddedToCommunity',
     'messageChatRemovedFromCommunity',
@@ -3725,6 +3727,12 @@ abstract final class TDParse {
         return telegramText(AppStringKeys.tdMessageGroupVideoChatEnded);
       case 'messageForumTopicCreated':
         return AppStrings.t(AppStringKeys.groupManagementLogCreatedTopic);
+      case 'messageForumTopicEdited':
+        return AppStrings.t(AppStringKeys.groupManagementLogEditedTopic);
+      case 'messageForumTopicIsClosedToggled':
+        return content?.boolean('is_closed') == true
+            ? AppStrings.t(AppStringKeys.groupManagementLogClosedTopic)
+            : AppStrings.t(AppStringKeys.groupManagementLogReopenedTopic);
       case 'messageChatBoost':
         return telegramText(AppStringKeys.tdMessageBoostedGroup);
       case 'messageChatAddedToCommunity':


### PR DESCRIPTION
## Problem

In forum topic (forum) views, messages sent by bots were invisible, and bot topic-rename / topic-close events showed up as normal messages instead of service messages.

## Root causes

**1. Bot messages dropped by the reply filter**

Bots sending messages in a forum topic via Bot API get `reply_to` set to the topic root message id by the Telegram server (this is how `message_thread_id` is represented). The post-stream filter in `topic_chat_view.dart` and `topic_channels_view.dart` used `replyToMessageId == null` to keep only root posts, which incorrectly treated this thread marker as a real reply and dropped every bot message.

**2. Missing service-message types**

`_serviceTypes` in `td_models.dart` included `messageForumTopicCreated` but was missing `messageForumTopicEdited` and `messageForumTopicIsClosedToggled`. As a result, bot topic-rename and topic-close events had `isService == false` and rendered as normal content messages.

## Fix

- **Reply filter**: treat `replyToMessageId == topic.id` as a thread marker, not a reply. Applied in both `topic_chat_view.dart` and `topic_channels_view.dart`.
- **Service types**: added `messageForumTopicEdited` and `messageForumTopicIsClosedToggled` to `_serviceTypes`, with corresponding `serviceText` cases.
- **Topic list**: `_loadTopics` no longer skips a topic when its `last_message` is a service message (e.g. a rename). Instead it falls back to a synthetic message that preserves the real `last_message` date for correct sort order.
- **Localization**: added `groupManagementLogClosedTopic` / `groupManagementLogReopenedTopic` strings across all 8 languages (en, de, es, fr, ja, ko, zh-Hans, zh-Hant).

## Testing

`flutter analyze` passes with no issues on the full project.