### PR TITLE
fix: folder tab strip auto-scrolls to active folder on swipe

### DIFF
--- a/lib/chats/chat_list_view.dart
+++ b/lib/chats/chat_list_view.dart
@@ -1066,7 +1066,6 @@ class _ChatListViewState extends State<ChatListView>
       if (ctx == null) return;
       Scrollable.ensureVisible(
         ctx,
-        alignment: 0.5,
         duration: const Duration(milliseconds: 250),
         curve: Curves.easeOutCubic,
       );

--- a/lib/chats/chat_list_view.dart
+++ b/lib/chats/chat_list_view.dart
@@ -604,6 +604,8 @@ class _ChatListViewState extends State<ChatListView>
   bool _reactivationSyncScheduled = false;
   int _lastVisibleRows = 1;
   final ChatListSwipeSession _chatListSwipeSession = ChatListSwipeSession();
+  final ScrollController _folderTabScrollController = ScrollController();
+  final Map<int?, GlobalKey> _folderTabKeys = {};
   int _nextComposerFocusRequestId = 0;
   OverlayEntry? _desktopChatMenuEntry;
   OverlayEntry? _desktopPlusMenuEntry;
@@ -735,6 +737,7 @@ class _ChatListViewState extends State<ChatListView>
     _folderTransitionController.dispose();
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
+    _folderTabScrollController.dispose();
     _model.removeListener(_onModel);
     _model.dispose();
     super.dispose();
@@ -1052,6 +1055,22 @@ class _ChatListViewState extends State<ChatListView>
     } else {
       _folderTransitionController.forward(from: 0);
     }
+    _ensureFolderTabVisible(filter.folderId);
+  }
+
+  void _ensureFolderTabVisible(int? folderId) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final key = _folderTabKeys[folderId];
+      final ctx = key?.currentContext;
+      if (ctx == null) return;
+      Scrollable.ensureVisible(
+        ctx,
+        alignment: 0.5,
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeOutCubic,
+      );
+    });
   }
 
   void _onControllerRequest() {
@@ -1518,6 +1537,7 @@ class _ChatListViewState extends State<ChatListView>
         border: Border(bottom: BorderSide(color: c.divider, width: 0.5)),
       ),
       child: ListView.separated(
+        controller: _folderTabScrollController,
         scrollDirection: Axis.horizontal,
         padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
         itemCount: _model.filters.length,
@@ -1525,7 +1545,12 @@ class _ChatListViewState extends State<ChatListView>
         itemBuilder: (context, index) {
           final filter = _model.filters[index];
           final selected = filter.folderId == selectedFolderId;
+          final key = _folderTabKeys.putIfAbsent(
+            filter.folderId,
+            () => GlobalKey(),
+          );
           return GestureDetector(
+            key: key,
             behavior: HitTestBehavior.opaque,
             onTap: () => _selectFilter(filter),
             child: SizedBox(


### PR DESCRIPTION
## Problem

When switching chat folders via left/right swipe, the top tab strip doesn't scroll. If the destination folder is off-screen (beyond the visible tab area), the user can't see which folder they landed on — the active tab is selected but invisible.

## Root cause

The folder tab strip is a horizontal `ListView.separated` with no `ScrollController`. `_switchToFilter` updates the model and animates the underline indicator, but never tells the tab list to scroll to the newly selected tab.

## Fix

- Added a `ScrollController` (`_folderTabScrollController`) to the tab `ListView`.
- Each tab gets a `GlobalKey` stored in a `Map<int?, GlobalKey>` keyed by `folderId`.
- After `_switchToFilter`, a post-frame callback calls `Scrollable.ensureVisible` on the selected tab's context with `alignment: 0.5` (centered), so the tab strip scrolls smoothly to bring the active folder into view.
- The controller is disposed in `dispose()`.

Works for both swipe-initiated and tap-initiated folder switches.

## Testing

`flutter analyze` passes (one pre-existing info-level lint, no errors).