### PR TITLE
fix: settings switch thumb color follows theme brightness

### DIFF
--- a/lib/components/ui_components.dart
+++ b/lib/components/ui_components.dart
@@ -628,7 +628,8 @@ class AppSwitch extends StatelessWidget {
     final padding = pointerDense ? 2.0 : 2.0;
     final handleSize = pointerDense ? 18.0 : 26.0;
     final trackColor = value ? c.linkBlue : c.textTertiary;
-    final handleColor = value ? c.onAccent : const Color(0xFFFFFFFF);
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final handleColor = isDark ? const Color(0xFF171717) : const Color(0xFFFFFFFF);
     return AppInteractiveSurface(
       semanticLabel:
           semanticLabel ??


### PR DESCRIPTION
## Problem

In Settings, all toggle switches showed a white thumb when off and a black thumb when on, regardless of the active theme (light or dark). This happened because:

- OFF state: thumb hardcoded to `Color(0xFFFFFFFF)` (white)
- ON state: thumb used `c.onAccent`, which for cloud themes with light accent colors resolves to dark (`0x171717`) via `readableForeground`

So the thumb color depended on the toggle state, not the theme.

## Fix

Changed `AppSwitch` to use `Theme.of(context).brightness` for the thumb color:
- Light theme: white thumb (`0xFFFFFFFF`) in both on and off states
- Dark theme: dark thumb (`0x171717`) in both on and off states

This makes the thumb color consistent within each theme, matching user expectations: "light theme uses white, dark theme uses black".

## Testing

`flutter analyze` passes with no issues.