### PR TITLE
fix: bot messages still invisible in forum topics

### DIFF
--- a/lib/channels/topic_chat_view.dart
+++ b/lib/channels/topic_chat_view.dart
@@ -408,11 +408,6 @@ class _TopicChatViewState extends State<TopicChatView> {
               .map(TDParse.message)
               .whereType<ChatMessage>()
               .where((message) => !message.isService)
-              .where(
-                (message) =>
-                    message.replyToMessageId == null ||
-                    message.replyToMessageId == topic.id,
-              )
               .toList()
             ..sort((a, b) => b.date.compareTo(a.date));
       _topicMessages[topic.id] = messages.isEmpty


### PR DESCRIPTION
Previous fix (PR #58) relaxed the replyToMessageId filter to allow `replyToMessageId == topic.id`, but bot messages are still being dropped — their replyToMessageId doesn't match topic.id in practice.

Since getForumTopicHistory already returns only messages from the specified topic, the replyToMessageId filter is unnecessary. Removing it so all non-service messages in the topic are shown, including bot messages.