### PR TITLE
Fix font size setting: scale chat text, scope it to chat surfaces

### DIFF
--- a/lib/app/desktop_chat_window.dart
+++ b/lib/app/desktop_chat_window.dart
@@ -330,7 +330,6 @@ class _DesktopChatWindowAppState extends State<DesktopChatWindowApp> {
               ],
             );
             return _DesktopChatScaledView(
-              fontScale: _theme.fontScale,
               interfaceScale: _theme.renderedInterfaceScale,
               child: appSurface,
             );
@@ -480,12 +479,10 @@ class _DesktopStandaloneChatSurfaceState
 
 class _DesktopChatScaledView extends StatelessWidget {
   const _DesktopChatScaledView({
-    required this.fontScale,
     required this.interfaceScale,
     required this.child,
   });
 
-  final double fontScale;
   final double interfaceScale;
   final Widget child;
 
@@ -497,18 +494,12 @@ class _DesktopChatScaledView extends StatelessWidget {
       media.size.width / scale,
       media.size.height / scale,
     );
-    final systemFontScale = media.textScaler.scale(1.0);
-    final effectiveFontScale = (fontScale * systemFontScale).clamp(
-      ThemeController.minFontScale,
-      ThemeController.maxFontScale,
-    );
     final scaledMedia = media.copyWith(
       size: virtualSize,
       padding: _unscale(media.padding, scale),
       viewPadding: _unscale(media.viewPadding, scale),
       viewInsets: _unscale(media.viewInsets, scale),
       systemGestureInsets: _unscale(media.systemGestureInsets, scale),
-      textScaler: TextScaler.linear(effectiveFontScale),
     );
     return AppKeyboardDismissOnTap(
       child: ClipRect(

--- a/lib/app/desktop_chat_window.dart
+++ b/lib/app/desktop_chat_window.dart
@@ -497,13 +497,18 @@ class _DesktopChatScaledView extends StatelessWidget {
       media.size.width / scale,
       media.size.height / scale,
     );
+    final systemFontScale = media.textScaler.scale(1.0);
+    final effectiveFontScale = (fontScale * systemFontScale).clamp(
+      ThemeController.minFontScale,
+      ThemeController.maxFontScale,
+    );
     final scaledMedia = media.copyWith(
       size: virtualSize,
       padding: _unscale(media.padding, scale),
       viewPadding: _unscale(media.viewPadding, scale),
       viewInsets: _unscale(media.viewInsets, scale),
       systemGestureInsets: _unscale(media.systemGestureInsets, scale),
-      textScaler: TextScaler.linear(fontScale),
+      textScaler: TextScaler.linear(effectiveFontScale),
     );
     return AppKeyboardDismissOnTap(
       child: ClipRect(

--- a/lib/app/desktop_utility_window.dart
+++ b/lib/app/desktop_utility_window.dart
@@ -1001,13 +1001,18 @@ class _DesktopUtilityScaledView extends StatelessWidget {
       media.size.width / scale,
       media.size.height / scale,
     );
+    final systemFontScale = media.textScaler.scale(1.0);
+    final effectiveFontScale = (fontScale * systemFontScale).clamp(
+      ThemeController.minFontScale,
+      ThemeController.maxFontScale,
+    );
     final scaledMedia = media.copyWith(
       size: virtualSize,
       padding: _unscale(media.padding, scale),
       viewPadding: _unscale(media.viewPadding, scale),
       viewInsets: _unscale(media.viewInsets, scale),
       systemGestureInsets: _unscale(media.systemGestureInsets, scale),
-      textScaler: TextScaler.linear(fontScale),
+      textScaler: TextScaler.linear(effectiveFontScale),
     );
     return AppKeyboardDismissOnTap(
       child: ClipRect(

--- a/lib/app/desktop_utility_window.dart
+++ b/lib/app/desktop_utility_window.dart
@@ -833,7 +833,6 @@ class _DesktopUtilityWindowAppState extends State<DesktopUtilityWindowApp> {
               return ColoredBox(color: currentTheme.scaffoldBackgroundColor);
             }
             return _DesktopUtilityScaledView(
-              fontScale: _theme.fontScale,
               interfaceScale: _theme.renderedInterfaceScale,
               child: appSurface,
             );
@@ -984,12 +983,10 @@ class _DesktopLocationPickerRootState
 
 class _DesktopUtilityScaledView extends StatelessWidget {
   const _DesktopUtilityScaledView({
-    required this.fontScale,
     required this.interfaceScale,
     required this.child,
   });
 
-  final double fontScale;
   final double interfaceScale;
   final Widget child;
 
@@ -1001,18 +998,12 @@ class _DesktopUtilityScaledView extends StatelessWidget {
       media.size.width / scale,
       media.size.height / scale,
     );
-    final systemFontScale = media.textScaler.scale(1.0);
-    final effectiveFontScale = (fontScale * systemFontScale).clamp(
-      ThemeController.minFontScale,
-      ThemeController.maxFontScale,
-    );
     final scaledMedia = media.copyWith(
       size: virtualSize,
       padding: _unscale(media.padding, scale),
       viewPadding: _unscale(media.viewPadding, scale),
       viewInsets: _unscale(media.viewInsets, scale),
       systemGestureInsets: _unscale(media.systemGestureInsets, scale),
-      textScaler: TextScaler.linear(effectiveFontScale),
     );
     return AppKeyboardDismissOnTap(
       child: ClipRect(

--- a/lib/channels/topic_channels_view.dart
+++ b/lib/channels/topic_channels_view.dart
@@ -25,6 +25,7 @@ import '../tdlib/json_helpers.dart';
 import '../tdlib/td_client.dart';
 import '../tdlib/td_models.dart';
 import '../theme/app_theme.dart';
+import '../theme/chat_font_scale_scope.dart';
 import '../theme/date_text.dart';
 import '../theme/theme_controller.dart';
 import 'topic_chat_view.dart';
@@ -549,16 +550,18 @@ class _TopicPostRow extends StatelessWidget {
             ),
             if (_hasRenderableContent) ...[
               const SizedBox(height: 12),
-              TopicPostContent(
-                chatId: post.chat.id,
-                message: post.message,
-                text: text,
-                maxTextLines: 6,
-                textOverflow: TextOverflow.ellipsis,
-                textStyle: TextStyle(
-                  fontSize: chatTextSize,
-                  height: 1.35,
-                  color: c.textPrimary,
+              ChatFontScaleScope(
+                child: TopicPostContent(
+                  chatId: post.chat.id,
+                  message: post.message,
+                  text: text,
+                  maxTextLines: 6,
+                  textOverflow: TextOverflow.ellipsis,
+                  textStyle: TextStyle(
+                    fontSize: chatTextSize,
+                    height: 1.35,
+                    color: c.textPrimary,
+                  ),
                 ),
               ),
             ],

--- a/lib/channels/topic_chat_view.dart
+++ b/lib/channels/topic_chat_view.dart
@@ -35,6 +35,7 @@ import '../tdlib/td_client.dart';
 import '../tdlib/td_models.dart';
 import '../theme/app_motion.dart';
 import '../theme/app_theme.dart';
+import '../theme/chat_font_scale_scope.dart';
 import '../theme/date_text.dart';
 import '../theme/theme_controller.dart';
 import 'topic_post_content.dart';
@@ -1040,13 +1041,13 @@ class _TopicChatViewState extends State<TopicChatView> {
         children: [
           _header(),
           if (_selectedThreadId == null && widget.chat.lastMessage.isNotEmpty)
-            _pinnedLine(),
-          Expanded(child: _content()),
+            ChatFontScaleScope(child: _pinnedLine()),
+          Expanded(child: ChatFontScaleScope(child: _content())),
           if (canComposeInTopicSurface(
             chat: widget.chat,
             forumTopicId: _selectedThreadId,
           ))
-            _bottomComposer(),
+            ChatFontScaleScope(child: _bottomComposer()),
         ],
       ),
     );

--- a/lib/chat/chat_view.dart
+++ b/lib/chat/chat_view.dart
@@ -56,6 +56,7 @@ import '../tdlib/td_client.dart';
 import '../tdlib/td_models.dart';
 import '../theme/app_motion.dart';
 import '../theme/app_theme.dart';
+import '../theme/chat_font_scale_scope.dart';
 import '../theme/date_text.dart';
 import '../theme/telegram_cloud_theme.dart';
 import '../theme/theme_controller.dart';
@@ -5943,24 +5944,26 @@ class _ChatViewState extends State<ChatView> {
                                           : _header()),
                                 body: showPeerRestrictionBlock
                                     ? _restrictedPeerBlockPage()
-                                    : Column(
-                                        children: [
-                                          Expanded(
-                                            child: _transcriptLayer(
-                                              searchPane: searchPane,
+                                    : ChatFontScaleScope(
+                                        child: Column(
+                                          children: [
+                                            Expanded(
+                                              child: _transcriptLayer(
+                                                searchPane: searchPane,
+                                              ),
                                             ),
-                                          ),
-                                          _chatMusicPlayer(),
-                                          // A narrow chat trades the composer
-                                          // for the hit navigator; a wide one
-                                          // keeps composing beside the results.
-                                          if (searching && !searchPane)
-                                            _searchNavigator()
-                                          else if (_isSelecting)
-                                            _selectionActionBar()
-                                          else
-                                            _composerArea(),
-                                        ],
+                                            _chatMusicPlayer(),
+                                            // A narrow chat trades the composer
+                                            // for the hit navigator; a wide one
+                                            // keeps composing beside the results.
+                                            if (searching && !searchPane)
+                                              _searchNavigator()
+                                            else if (_isSelecting)
+                                              _selectionActionBar()
+                                            else
+                                              _composerArea(),
+                                          ],
+                                        ),
                                       ),
                                 trailingPane: searchPane
                                     ? _searchResultsPane()

--- a/lib/chat/message_bubble.dart
+++ b/lib/chat/message_bubble.dart
@@ -1026,14 +1026,17 @@ class _MessageBubbleState extends State<MessageBubble>
               role: showSenderRole ? message.senderRole : null,
               roleTitle: showSenderRole && showMemberTags ? senderTitle : null,
               roleAfterName: isDesktopTargetPlatform(),
-              trailing: showStatus
-                  ? StatusEmojiView(
-                      id: message.senderEmojiStatusId,
-                      size: 14,
-                      color: senderNameColor,
-                      animate: theme.chatStatusEmojiMode.animate,
-                    )
-                  : null,
+          trailing: showStatus
+              ? StatusEmojiView(
+                  id: message.senderEmojiStatusId,
+                  // The name beside it scales with the chat font size; the
+                  // status emoji should grow with it instead of staying at a
+                  // fixed pixel size.
+                  size: 14 * MediaQuery.textScalerOf(context).scale(1.0),
+                  color: senderNameColor,
+                  animate: theme.chatStatusEmojiMode.animate,
+                )
+              : null,
             ),
           ),
           const SizedBox(width: 5),

--- a/lib/chat/message_bubble.dart
+++ b/lib/chat/message_bubble.dart
@@ -4084,7 +4084,10 @@ class _MessageBubbleState extends State<MessageBubble>
       widgets.add(
         Align(
           alignment: Alignment.centerRight,
-          child: RichText(text: TextSpan(children: [_metaSpan(outgoing)])),
+          child: RichText(
+            textScaler: MediaQuery.textScalerOf(context),
+            text: TextSpan(children: [_metaSpan(outgoing)]),
+          ),
         ),
       );
     }
@@ -4120,6 +4123,7 @@ class _MessageBubbleState extends State<MessageBubble>
     ).style.merge(TextStyle(fontSize: effectiveFontSize, color: base));
     return Builder(
       builder: (context) => RichText(
+        textScaler: MediaQuery.textScalerOf(context),
         maxLines: maxLines,
         overflow: maxLines == null ? TextOverflow.clip : TextOverflow.fade,
         text: TextSpan(style: style, children: children),

--- a/lib/chat/telegram_rich_text.dart
+++ b/lib/chat/telegram_rich_text.dart
@@ -88,6 +88,7 @@ class _TelegramRichTextState extends State<TelegramRichText> {
       return _richTextWithQuoteBlocks(context, baseStyle, linkColor);
     }
     return RichText(
+      textScaler: MediaQuery.textScalerOf(context),
       maxLines: widget.maxLines,
       overflow: widget.overflow,
       text: TextSpan(
@@ -349,13 +350,17 @@ class _TelegramRichTextState extends State<TelegramRichText> {
     final style = _entityStyle(context, effectiveActive, baseStyle, linkColor);
     final customEmojiId = _customEmojiId(effectiveActive);
     if (customEmojiId != null) {
+      final ambientScaler = MediaQuery.textScalerOf(context);
       return [
         WidgetSpan(
           alignment: PlaceholderAlignment.middle,
           child: SelectableCustomEmojiView(
             id: customEmojiId,
             fallbackText: segment,
-            size: (style.fontSize ?? baseStyle.fontSize ?? 16) * 1.25,
+            size:
+                (style.fontSize ?? baseStyle.fontSize ?? 16) *
+                ambientScaler.scale(1.0) *
+                1.25,
             color: style.color,
           ),
         ),

--- a/lib/components/ui_components.dart
+++ b/lib/components/ui_components.dart
@@ -1850,6 +1850,7 @@ class ChatPreviewText extends StatelessWidget {
       context,
     ).style.merge(TextStyle(fontSize: fontSize));
     return RichText(
+      textScaler: MediaQuery.textScalerOf(context),
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
       text: TextSpan(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -793,7 +793,6 @@ class _MithkaAppState extends State<MithkaApp> with WidgetsBindingObserver {
             theme: _themeData(Brightness.light, theme),
             darkTheme: _themeData(Brightness.dark, theme),
             themeMode: theme.themeMode,
-            // Apply the user's chosen font size app-wide (设置 › 通用 › 字体大小).
             builder: (context, child) {
               // Aspect-scoped: MediaQuery.of would re-run this whole closure on
               // every keyboard-inset and window-resize frame just to read
@@ -877,7 +876,6 @@ class _MithkaAppState extends State<MithkaApp> with WidgetsBindingObserver {
               return AnnotatedRegion<SystemUiOverlayStyle>(
                 value: systemUiOverlayStyleForSurface(context.colors.navBar),
                 child: _ScaledAppView(
-                  fontScale: theme.fontScale,
                   interfaceScale: theme.renderedInterfaceScale,
                   child: DefaultTextStyle(
                     style: theme.applyAppTextStyle(
@@ -939,13 +937,8 @@ List<NavigatorObserver> _telemetryNavigatorObservers() {
 }
 
 class _ScaledAppView extends StatelessWidget {
-  const _ScaledAppView({
-    required this.fontScale,
-    required this.interfaceScale,
-    required this.child,
-  });
+  const _ScaledAppView({required this.interfaceScale, required this.child});
 
-  final double fontScale;
   final double interfaceScale;
   final Widget child;
 
@@ -957,24 +950,15 @@ class _ScaledAppView extends StatelessWidget {
       media.size.width / scale,
       media.size.height / scale,
     );
-    // Honour the platform accessibility text size underneath the user's own
-    // font preference. The product stays capped at the app's tested range so
-    // extreme system settings cannot break fixed layouts.
-    final systemFontScale = media.textScaler.scale(1.0);
-    final effectiveFontScale = (fontScale * systemFontScale).clamp(
-      ThemeController.minFontScale,
-      ThemeController.maxFontScale,
-    );
+    // The system text scaler flows through untouched: the in-app font size
+    // setting is scoped to chat surfaces by ChatFontScaleScope, and the outer
+    // transform scales geometry and text together for interface size.
     final scaledMedia = media.copyWith(
       size: virtualSize,
       padding: _unscaleInsets(media.padding, scale),
       viewPadding: _unscaleInsets(media.viewPadding, scale),
       viewInsets: _unscaleInsets(media.viewInsets, scale),
       systemGestureInsets: _unscaleInsets(media.systemGestureInsets, scale),
-      // The outer transform scales geometry and text together. Keep only the
-      // independent font preference here; dividing by interfaceScale caused
-      // normal Text widgets to stay small while noScaling text still grew.
-      textScaler: TextScaler.linear(effectiveFontScale),
     );
 
     return AppKeyboardDismissOnTap(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -957,6 +957,14 @@ class _ScaledAppView extends StatelessWidget {
       media.size.width / scale,
       media.size.height / scale,
     );
+    // Honour the platform accessibility text size underneath the user's own
+    // font preference. The product stays capped at the app's tested range so
+    // extreme system settings cannot break fixed layouts.
+    final systemFontScale = media.textScaler.scale(1.0);
+    final effectiveFontScale = (fontScale * systemFontScale).clamp(
+      ThemeController.minFontScale,
+      ThemeController.maxFontScale,
+    );
     final scaledMedia = media.copyWith(
       size: virtualSize,
       padding: _unscaleInsets(media.padding, scale),
@@ -966,7 +974,7 @@ class _ScaledAppView extends StatelessWidget {
       // The outer transform scales geometry and text together. Keep only the
       // independent font preference here; dividing by interfaceScale caused
       // normal Text widgets to stay small while noScaling text still grew.
-      textScaler: TextScaler.linear(fontScale),
+      textScaler: TextScaler.linear(effectiveFontScale),
     );
 
     return AppKeyboardDismissOnTap(

--- a/lib/moments/moments_view.dart
+++ b/lib/moments/moments_view.dart
@@ -4268,6 +4268,7 @@ class _PostReplyQuote extends StatelessWidget {
           if (hasText)
             Expanded(
               child: RichText(
+                textScaler: MediaQuery.textScalerOf(context),
                 maxLines: 4,
                 overflow: TextOverflow.ellipsis,
                 text: TextSpan(

--- a/lib/settings/appearance_view.dart
+++ b/lib/settings/appearance_view.dart
@@ -35,6 +35,7 @@ import '../platform/adaptive_platform.dart';
 import '../tdlib/td_models.dart';
 import '../theme/app_motion.dart';
 import '../theme/app_theme.dart';
+import '../theme/chat_font_scale_scope.dart';
 import '../theme/emoji_font_catalog.dart';
 import '../theme/global_theme_view.dart';
 import '../theme/message_bubble_background.dart';
@@ -1167,97 +1168,6 @@ class _ChatViewQuickReactionOverlay extends StatelessWidget {
   }
 }
 
-class _RepresentativeChatListRow extends StatelessWidget {
-  const _RepresentativeChatListRow({required this.theme});
-
-  final ThemeController theme;
-
-  @override
-  Widget build(BuildContext context) {
-    final c = context.colors;
-    return Padding(
-      padding: const EdgeInsets.all(AppSpacing.lg),
-      child: Row(
-        children: [
-          Container(
-            width: theme.avatarSize,
-            height: theme.avatarSize,
-            decoration: BoxDecoration(
-              color: AppTheme.brand.withValues(alpha: 0.16),
-              shape: BoxShape.circle,
-            ),
-            alignment: Alignment.center,
-            child: AppIcon(
-              HeroAppIcons.solidMessage,
-              size: AppIconSize.xl,
-              color: AppTheme.brand,
-            ),
-          ),
-          const SizedBox(width: AppSpacing.lg),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  AppStrings.t(AppStringKeys.appearancePreviewUsersSample),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    fontSize: AppTextSize.bodyLarge,
-                    fontWeight: FontWeight.w600,
-                    color: c.textPrimary,
-                  ),
-                ),
-                const SizedBox(height: AppSpacing.xxs),
-                Text(
-                  AppStrings.t(AppStringKeys.appearancePreviewMessageSample),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    fontSize: AppTextSize.footnote,
-                    color: c.textSecondary,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(width: AppSpacing.md),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              Text(
-                '10:42',
-                style: TextStyle(
-                  fontSize: AppTextSize.caption,
-                  color: c.textTertiary,
-                ),
-              ),
-              const SizedBox(height: AppSpacing.xs),
-              Container(
-                width: 18,
-                height: 18,
-                decoration: BoxDecoration(
-                  color: AppTheme.brand,
-                  shape: BoxShape.circle,
-                ),
-                alignment: Alignment.center,
-                child: const Text(
-                  '2',
-                  style: TextStyle(
-                    color: Color(0xFFFFFFFF),
-                    fontSize: AppTextSize.caption,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-}
-
 class _RepresentativeMessageBubble extends StatelessWidget {
   const _RepresentativeMessageBubble();
 
@@ -1660,26 +1570,9 @@ extension _DisplayAppearanceHelpers on AppearanceView {
             ),
           ),
           const SizedBox(height: AppSpacing.md),
-          const _RepresentativeMessageBubble(),
-          const SizedBox(height: AppSpacing.xl),
-          Text(
-            AppStrings.t(AppStringKeys.appearanceChatList),
-            style: TextStyle(
-              fontSize: AppTextSize.caption,
-              color: context.colors.textTertiary,
-            ),
-          ),
-          const SizedBox(height: AppSpacing.md),
-          Container(
-            key: const ValueKey('font-size-chat-list-preview'),
-            decoration: BoxDecoration(
-              color: context.colors.background,
-              borderRadius: BorderRadius.circular(AppRadius.control),
-              border: Border.all(color: context.colors.divider),
-            ),
-            clipBehavior: Clip.antiAlias,
-            child: _RepresentativeChatListRow(theme: theme),
-          ),
+          // The font size setting is scoped to chat surfaces, so the preview
+          // simulates that scope rather than reading the ambient scaler.
+          const ChatFontScaleScope(child: _RepresentativeMessageBubble()),
         ],
       ),
     );

--- a/lib/theme/chat_font_scale_scope.dart
+++ b/lib/theme/chat_font_scale_scope.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
+import 'theme_controller.dart';
+
+/// Applies the user's chat font size (设置 › 外观 › 字体大小) to [child] only.
+///
+/// The font preference used to ride the root MediaQuery, which scaled every
+/// label in the app while RichText-based message bubbles stayed put. Scoping
+/// the factor to chat surfaces makes the setting do what it says: message
+/// text, captions, and the composer scale; navigation, lists, and settings
+/// keep their size. The factor composes with the ambient (system) scaler so
+/// accessibility settings still apply inside chats.
+class ChatFontScaleScope extends StatelessWidget {
+  const ChatFontScaleScope({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final fontScale = context.watch<ThemeController>().fontScale;
+    final media = MediaQuery.of(context);
+    final composed = fontScale * media.textScaler.scale(1.0);
+    return MediaQuery(
+      data: media.copyWith(textScaler: TextScaler.linear(composed)),
+      child: child,
+    );
+  }
+}

--- a/lib/theme/theme_controller.dart
+++ b/lib/theme/theme_controller.dart
@@ -1801,11 +1801,12 @@ class ThemeController extends ChangeNotifier {
     return value;
   }
 
-  /// App-wide text scale factor, applied at the root via MediaQuery.textScaler.
+  /// App-wide text scale factor for chat surfaces, applied by
+  /// [ChatFontScaleScope] through a scoped MediaQuery.textScaler.
   double get fontScale => _fontScale;
-  // Font scaling is applied once by the root MediaQuery; Text applies it
-  // implicitly and RichText reads it explicitly. Returning an already scaled
-  // size here made chat typography grow twice while navigation text grew once.
+  // Chat font scaling is applied once by the chat-scoped MediaQuery; Text
+  // applies it implicitly and RichText reads it explicitly. Returning an
+  // already scaled size here made chat typography grow twice.
   double chatTextSize(double base) => base;
 
   /// Squared value shown by the Interface Size control. For example, the

--- a/lib/theme/theme_controller.dart
+++ b/lib/theme/theme_controller.dart
@@ -1803,9 +1803,9 @@ class ThemeController extends ChangeNotifier {
 
   /// App-wide text scale factor, applied at the root via MediaQuery.textScaler.
   double get fontScale => _fontScale;
-  // Font scaling is applied once by the root MediaQuery. Returning an already
-  // scaled size here made chat typography grow twice while navigation text
-  // grew once.
+  // Font scaling is applied once by the root MediaQuery; Text applies it
+  // implicitly and RichText reads it explicitly. Returning an already scaled
+  // size here made chat typography grow twice while navigation text grew once.
   double chatTextSize(double base) => base;
 
   /// Squared value shown by the Interface Size control. For example, the

--- a/lib/theme/theme_controller.dart
+++ b/lib/theme/theme_controller.dart
@@ -1236,7 +1236,9 @@ class ThemeController extends ChangeNotifier {
   static const _unreadBadgeOverflowModeKey = 'unreadBadgeOverflowMode';
 
   static const double minFontScale = 0.8;
-  static const double maxFontScale = 1.4;
+  // Chat text reflows inside fixed bubble widths, so a generous ceiling is
+  // safe: 2.0 covers users the old 1.4 cap left behind.
+  static const double maxFontScale = 2.0;
   static const double minInterfaceScale = 0.66 * 0.66;
   static const double maxInterfaceScale = 1.50 * 1.50;
 

--- a/test/appearance_theming_test.dart
+++ b/test/appearance_theming_test.dart
@@ -27,7 +27,7 @@ void main() {
     expect(ThemeController(prefs).themingEnabled, isFalse);
   });
 
-  test('chat font size is not pre-scaled before root text scaling', () async {
+  test('chat font size is not pre-scaled before scoped text scaling', () async {
     SharedPreferences.setMockInitialValues({'fontScale': 1.5});
     final prefs = await SharedPreferences.getInstance();
     final controller = ThemeController(prefs);
@@ -607,12 +607,13 @@ void main() {
       find.byKey(const ValueKey('font-size-chat-preview')),
       findsOneWidget,
     );
+    // Font size is scoped to chat surfaces, so the preview no longer shows
+    // a chat-list row.
     expect(
       find.byKey(const ValueKey('font-size-chat-list-preview')),
-      findsOneWidget,
+      findsNothing,
     );
     expect(find.text('This is how chat text will look.'), findsOneWidget);
-    expect(find.text('Mithka Users'), findsOneWidget);
 
     tester.state<NavigatorState>(find.byType(Navigator).first).pop();
     await tester.pumpAndSettle();

--- a/test/chat_font_scale_scope_test.dart
+++ b/test/chat_font_scale_scope_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mithka/theme/chat_font_scale_scope.dart';
+import 'package:mithka/theme/theme_controller.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  testWidgets('chat scope scales its subtree and leaves the rest alone', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({'fontScale': 1.5});
+    final prefs = await SharedPreferences.getInstance();
+    final controller = ThemeController(prefs);
+
+    TextScaler? inside;
+    TextScaler? outside;
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ThemeController>.value(
+        value: controller,
+        child: MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(1.2)),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Column(
+              children: [
+                ChatFontScaleScope(
+                  child: Builder(
+                    builder: (context) {
+                      inside = MediaQuery.textScalerOf(context);
+                      return const SizedBox.shrink();
+                    },
+                  ),
+                ),
+                Builder(
+                  builder: (context) {
+                    outside = MediaQuery.textScalerOf(context);
+                    return const SizedBox.shrink();
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // 1.2 system × 1.5 user preference inside the scope, 1.2 outside.
+    expect(inside!.scale(10), closeTo(18, 0.001));
+    expect(outside!.scale(10), closeTo(12, 0.001));
+  });
+
+  testWidgets('chat scope tracks fontScale changes', (tester) async {
+    SharedPreferences.setMockInitialValues({'fontScale': 1.0});
+    final prefs = await SharedPreferences.getInstance();
+    final controller = ThemeController(prefs);
+
+    TextScaler? inside;
+    Future<void> pump() => tester.pumpWidget(
+      ChangeNotifierProvider<ThemeController>.value(
+        value: controller,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: ChatFontScaleScope(
+              child: Builder(
+                builder: (context) {
+                  inside = MediaQuery.textScalerOf(context);
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await pump();
+    expect(inside!.scale(10), 10);
+
+    controller.fontScale = 1.4;
+    await pump();
+    expect(inside!.scale(10), 14);
+
+    // The setter debounces a SharedPreferences write on a 200 ms timer; let it
+    // run before the test tears the tree down.
+    await tester.pump(const Duration(milliseconds: 300));
+  });
+}

--- a/test/message_sender_status_emoji_test.dart
+++ b/test/message_sender_status_emoji_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mithka/chat/custom_emoji.dart';
+import 'package:mithka/chat/message_bubble.dart';
+import 'package:mithka/l10n/app_localizations.dart';
+import 'package:mithka/tdlib/td_models.dart';
+import 'package:mithka/theme/app_theme.dart';
+import 'package:mithka/theme/theme_controller.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('sender status emoji scales with the chat text scaler', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
+    final theme = ThemeController(preferences);
+    addTearDown(theme.dispose);
+
+    final message = ChatMessage(
+      id: 702,
+      isOutgoing: false,
+      text: 'hello',
+      date: 1,
+      contentType: 'messageText',
+      senderName: 'Alice',
+      senderEmojiStatusId: 42,
+    );
+
+    Widget bubble(double scale) => ChangeNotifierProvider<ThemeController>.value(
+      value: theme,
+      child: MaterialApp(
+        theme: ThemeData(extensions: [AppColors.light]),
+        locale: const Locale('en'),
+        localizationsDelegates: const [AppLocalizations.delegate],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: MediaQuery(
+          data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+          child: Scaffold(
+            body: TickerMode(
+              enabled: false,
+              child: MessageBubble(
+                message: message,
+                peerTitle: 'Test Group',
+                isGroup: true,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(bubble(1));
+    // CustomEmojiCenter debounces its load request on a 40 ms timer.
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(
+      tester.widget<StatusEmojiView>(find.byType(StatusEmojiView)).size,
+      14,
+    );
+
+    await tester.pumpWidget(bubble(2));
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(
+      tester.widget<StatusEmojiView>(find.byType(StatusEmojiView)).size,
+      28,
+    );
+  });
+}

--- a/test/rich_text_text_scaler_test.dart
+++ b/test/rich_text_text_scaler_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mithka/chat/telegram_rich_text.dart';
+import 'package:mithka/components/ui_components.dart';
+
+Widget _withScaler(double scale, Widget child) => MediaQuery(
+  data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+  child: Directionality(
+    textDirection: TextDirection.ltr,
+    child: Center(child: child),
+  ),
+);
+
+void main() {
+  testWidgets('TelegramRichText honours the ambient text scaler', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _withScaler(
+        1.5,
+        const TelegramRichText(text: 'hello', entities: []),
+      ),
+    );
+
+    final richText = tester.widget<RichText>(find.byType(RichText));
+    expect(richText.textScaler.scale(16), 24);
+  });
+
+  testWidgets('ChatPreviewText honours the ambient text scaler', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _withScaler(2.0, const ChatPreviewText(message: 'hello')),
+    );
+
+    final richText = tester.widget<RichText>(find.byType(RichText));
+    expect(richText.textScaler.scale(16), 32);
+  });
+}


### PR DESCRIPTION
## Problem

The font size slider (设置 › 外观 › 字体大小) barely worked:

- Message bubbles, captions, bios, and previews render through `RichText`, which ignores `MediaQuery.textScaler` by default — so the slider had **no effect on the text it exists for**. Only plain `Text` (navigation, lists, settings) responded.
- The root `MediaQuery` override replaced the system accessibility text scaler with `TextScaler.linear(fontScale)`, silently discarding iOS Dynamic Type / Android font settings.
- Font size and interface size multiplied app-wide (text grew by both), so neither slider's percentage matched the result.

## Changes

**Rich text responds to the font size setting**
- Pass the ambient `MediaQuery` text scaler into every user-facing `RichText` (`telegram_rich_text.dart`, message bubble body + meta, `ChatPreviewText`, moments reply preview). Inline custom emoji sizes are multiplied by the same factor so they keep pace with the text around them.

**Font size is scoped to chat surfaces**
- New `ChatFontScaleScope` (`lib/theme/chat_font_scale_scope.dart`) applies `fontScale × system scaler` through a scoped `MediaQuery` — wrapping the chat transcript and composer, the topic chat, and topic post content. Message text, captions, quotes, and the composer scale; navigation, chat lists, and settings do not.
- The root `_ScaledAppView` and both desktop window counterparts no longer override `textScaler`, so the system accessibility text size flows through the rest of the interface on its own.
- The appearance preview simulates the chat scope (otherwise it would show nothing changing), and drops the chat-list row the setting can no longer affect.
- Sender status emoji in group bubbles now scales with the sender name instead of staying at a fixed 14 px.
- Chat font size ceiling raised from 140% to 200% — bubble text reflows inside fixed widths, so a larger cap is safe.

## Tests

- New: `rich_text_text_scaler_test.dart`, `chat_font_scale_scope_test.dart` (scope scales its subtree, leaves the rest alone, tracks preference changes), `message_sender_status_emoji_test.dart` (14 px → 28 px at 2.0×).
- Updated `appearance_theming_test.dart` for the scoped preview.
- Full suite: 2156 tests pass. Built and verified on macOS (universal app).
