### PR TITLE
Centre the macOS traffic lights on the title bar identity row

### DIFF
--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -68,6 +68,12 @@ class MainFlutterWindow: NSWindow {
     configurePrimaryWindow()
   }
 
+  override func setFrame(_ frameRect: NSRect, display flag: Bool) {
+    super.setFrame(frameRect, display: flag)
+    // Resizing/zooming re-centres the buttons on the system titlebar strip.
+    alignTrafficLightsWithTitleBar()
+  }
+
   private func configurePrimaryWindow() {
     titleVisibility = .hidden
     titlebarAppearsTransparent = true
@@ -76,6 +82,33 @@ class MainFlutterWindow: NSWindow {
     minSize = NSSize(width: 820, height: 560)
     if #available(macOS 11.0, *) {
       titlebarSeparatorStyle = .none
+    }
+    DispatchQueue.main.async { [weak self] in
+      self?.alignTrafficLightsWithTitleBar()
+    }
+  }
+
+  /// The Flutter title bar (MacosDesktopTitleBar) is 40 pt tall from the
+  /// window's top edge, so the identity row sits on the 20 pt midline. The
+  /// stock traffic lights centre on the shorter system titlebar strip and
+  /// ride a few points above it — nudge them onto the same midline.
+  func alignTrafficLightsWithTitleBar() {
+    guard let close = standardWindowButton(.closeButton) else { return }
+    let centerInWindow = close.superview?.convert(
+      NSPoint(x: close.frame.midX, y: close.frame.midY),
+      to: nil
+    ) ?? NSPoint.zero
+    let currentFromTop = frame.height - centerInWindow.y
+    let delta = currentFromTop - 20
+    guard abs(delta) > 0.1 else { return }
+    for kind in [
+      NSWindow.ButtonType.closeButton,
+      .miniaturizeButton,
+      .zoomButton,
+    ] {
+      if let button = standardWindowButton(kind) {
+        button.frame.origin.y += delta
+      }
     }
   }
 }

--- a/macos/RunnerTests/RunnerTests.swift
+++ b/macos/RunnerTests/RunnerTests.swift
@@ -177,6 +177,35 @@ class RunnerTests: XCTestCase {
   }
 
   @MainActor
+  func testTrafficLightsCenterOnTheFlutterTitleBarMidline() throws {
+    let window = MainFlutterWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 820, height: 560),
+      styleMask: [
+        .titled, .closable, .miniaturizable, .resizable, .fullSizeContentView,
+      ],
+      backing: .buffered,
+      defer: false
+    )
+    window.contentViewController = NSViewController()
+    window.titlebarAppearsTransparent = true
+    window.orderFront(nil)
+    addTeardownBlock { @MainActor in
+      window.orderOut(nil)
+    }
+
+    window.alignTrafficLightsWithTitleBar()
+
+    let close = try XCTUnwrap(window.standardWindowButton(.closeButton))
+    let container = try XCTUnwrap(close.superview)
+    let centerInWindow = container.convert(
+      NSPoint(x: close.frame.midX, y: close.frame.midY),
+      to: nil
+    )
+    let fromTop = window.frame.height - centerInWindow.y
+    XCTAssertEqual(fromTop, 20, accuracy: 0.5)
+  }
+
+  @MainActor
   private func makeMainWindow() -> MainFlutterWindow {
     let window = MainFlutterWindow(
       contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),


### PR DESCRIPTION
## Problem

The primary window's traffic lights centre on the system titlebar strip, 16 pt from the window's top edge. The Flutter-owned title bar (`MacosDesktopTitleBar`) is 40 pt tall, so the avatar-and-name identity row sits on the 20 pt midline — the buttons ride 4 pt above it and look off-centre next to the username.

## Change

`MainFlutterWindow.alignTrafficLightsWithTitleBar()` measures the close button's centre in window coordinates and shifts all three buttons down onto the title bar's 20 pt midline. It runs after the initial layout and after every `setFrame`, so resizing, zooming, and fullscreen transitions keep the alignment.

Measured with a standalone script on macOS 27: before 16.00 pt, after 20.00 pt for all three buttons.

## Tests

- New native test `testTrafficLightsCenterOnTheFlutterTitleBarMidline` in `RunnerTests` asserts the close button centre lands at 20 pt from the window top.
- Not run locally — LaunchServices refuses to launch the test host from a CLI session here; relies on CI.

## Note

At non-default interface scales the Flutter title bar grows visually while native buttons cannot, so the alignment is exact at 100% and drifts slightly at other scales.
