### PR TITLE
Fix offscreen message jump positioning

### DIFF
--- a/lib/chat/chat_view.dart
+++ b/lib/chat/chat_view.dart
@@ -2884,6 +2884,35 @@ class _ChatViewState extends State<ChatView> {
     _scrollTargetId = messageId;
   }
 
+  /// Makes an arbitrary loaded target the first child after the scroll view's
+  /// center sliver, so Flutter lays it out without depending on guessed row
+  /// heights. The transcript keeps the same chronological order on both sides
+  /// of the new pivot; only its zero scroll coordinate moves to the target.
+  bool _stageMessageAtTranscriptCenter(int messageId) {
+    if (!_scroll.hasClients) return false;
+    ChatMessage? target;
+    for (final message in _vm.messages) {
+      if (message.id == messageId) {
+        target = message;
+        break;
+      }
+    }
+    if (target == null) return false;
+
+    final cutoff = _transcriptOrderId(target);
+    if (_transcriptPivot?.cutoffMessageId != cutoff ||
+        !_transcriptPivotFrozen) {
+      setState(() {
+        _transcriptPivot = TranscriptPivot(cutoff);
+        // Async sender, preview, and media hydration must not reset the pivot
+        // before the target's final alignment passes have completed.
+        _transcriptPivotFrozen = true;
+      });
+    }
+    _scroll.jumpTo(clampScrollOffset(_scroll.position, 0));
+    return true;
+  }
+
   void _cancelSessionScrollAnchorMaintenance() {
     _maintainSessionScrollAnchor = false;
   }
@@ -3106,7 +3135,11 @@ class _ChatViewState extends State<ChatView> {
 
   Future<void> _positionInitialTranscript() async {
     if (!_scroll.hasClients || _initialTranscriptPositioningAborted) return;
-    _jumpToInitialEstimate();
+    final initialTarget = _scrollTargetId;
+    if (initialTarget == null ||
+        !_stageMessageAtTranscriptCenter(initialTarget)) {
+      _jumpToInitialEstimate();
+    }
     for (var i = 0; i < 3; i++) {
       await WidgetsBinding.instance.endOfFrame;
       if (!mounted ||
@@ -7974,6 +8007,7 @@ class _ChatViewState extends State<ChatView> {
 
     final targetAlignment =
         alignment ?? (pinnedJump ? pinnedMessageScrollAlignment : 0.3);
+    var stagedAtTranscriptCenter = false;
     for (var tries = 0; tries < 6; tries++) {
       if (targetCancelled()) return false;
       final activeKey = _targetKey;
@@ -8008,32 +8042,70 @@ class _ChatViewState extends State<ChatView> {
           return false;
         }
         if (!mounted || !ctx.mounted || targetCancelled()) return false;
-        await Scrollable.ensureVisible(
-          ctx,
+        final aligned = await _alignMessageTarget(
+          activeKey,
           alignment: targetAlignment,
-          duration: instant
-              ? Duration.zero
-              : pinnedJump
-              ? const Duration(milliseconds: 140)
-              : const Duration(milliseconds: 220),
-          curve: Curves.easeOutCubic,
+          instant: instant,
+          pinnedJump: pinnedJump,
+          isCancelled: targetCancelled,
         );
-        if (mounted && !targetCancelled()) {
+        if (aligned && mounted && !targetCancelled()) {
           setState(() => _setScrollTarget(null));
           return true;
         }
         return false;
       }
       if (!_scroll.hasClients) return false;
-      final estimate = _estimateMessageOffset(messageId, targetAlignment);
-      if (estimate != null) _scroll.jumpTo(estimate);
-      await Future<void>.delayed(const Duration(milliseconds: 120));
+      // A loaded target can be arbitrarily far from the currently laid-out
+      // sliver children. Move the bidirectional transcript's center to that
+      // row once; unlike an absolute height estimate, this guarantees Flutter
+      // will build the target even when every preceding row was underestimated.
+      if (!stagedAtTranscriptCenter &&
+          _stageMessageAtTranscriptCenter(messageId)) {
+        stagedAtTranscriptCenter = true;
+      } else {
+        final estimate = _estimateMessageOffset(messageId, targetAlignment);
+        if (estimate != null) _scroll.jumpTo(estimate);
+      }
+      await WidgetsBinding.instance.endOfFrame;
       if (!mounted || targetCancelled()) return false;
     }
     if (mounted && !targetCancelled()) {
       setState(() => _setScrollTarget(null));
     }
     return false;
+  }
+
+  /// Repeats ordinary target alignment while rich content finishes laying out.
+  /// The first pass carries the visible motion; the two short correction passes
+  /// absorb thumbnail, preview, reaction, and text reflow during that motion.
+  Future<bool> _alignMessageTarget(
+    GlobalKey targetKey, {
+    required double alignment,
+    required bool instant,
+    required bool pinnedJump,
+    required bool Function() isCancelled,
+  }) async {
+    for (var pass = 0; pass < 3; pass++) {
+      if (isCancelled()) return false;
+      final ctx = targetKey.currentContext;
+      if (ctx == null || !ctx.mounted) return false;
+      await Scrollable.ensureVisible(
+        ctx,
+        alignment: alignment,
+        duration: instant
+            ? Duration.zero
+            : pass == 0
+            ? pinnedJump
+                  ? const Duration(milliseconds: 140)
+                  : const Duration(milliseconds: 220)
+            : const Duration(milliseconds: 80),
+        curve: Curves.easeOutCubic,
+      );
+      if (isCancelled()) return false;
+      await WidgetsBinding.instance.endOfFrame;
+    }
+    return !isCancelled();
   }
 
   /// Aligns a pinned target more than once because media rows can finish a

--- a/test/chat_bidirectional_sliver_anchor_test.dart
+++ b/test/chat_bidirectional_sliver_anchor_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -113,6 +114,60 @@ void main() {
 
     await tester.pumpAndSettle();
   });
+
+  for (final platformCase in const [
+    (name: 'Android', cacheExtent: 260.0),
+    (name: 'iOS', cacheExtent: 420.0),
+  ]) {
+    testWidgets(
+      '${platformCase.name} search targets survive badly underestimated rows',
+      (tester) async {
+        final controller = ScrollController();
+        final historyKey = GlobalKey<_TargetedHistoryPrototypeState>();
+        addTearDown(controller.dispose);
+
+        await tester.pumpWidget(
+          _testApp(
+            _TargetedHistoryPrototype(
+              key: historyKey,
+              controller: controller,
+              cacheExtent: platformCase.cacheExtent,
+            ),
+          ),
+        );
+
+        // The old search loop repeated this same estimate six times. Rows are
+        // actually 300 px tall here but estimated at 60 px, so neither mobile
+        // cache extent gets close enough to build the target.
+        for (var attempt = 0; attempt < 6; attempt++) {
+          controller.jumpTo(_TargetedHistoryPrototype.staleEstimate);
+          await tester.pump();
+        }
+        expect(find.byKey(_TargetedHistoryPrototype.targetKey), findsNothing);
+
+        // Moving the center pivot to the target makes it index zero of the
+        // after-center sliver. It is built on the next frame independently of
+        // cache extent or the accumulated height-estimation error.
+        historyKey.currentState!.stageTargetAtCenter();
+        await tester.pump();
+        expect(find.byKey(_TargetedHistoryPrototype.targetKey), findsOneWidget);
+
+        final targetContext = historyKey.currentState!.targetContext;
+        expect(targetContext, isNotNull);
+        await Scrollable.ensureVisible(targetContext!, alignment: 0.38);
+        await tester.pump();
+
+        final viewport = tester.getRect(
+          find.byKey(_TargetedHistoryPrototype.scrollViewKey),
+        );
+        final target = tester.getRect(
+          find.byKey(_TargetedHistoryPrototype.targetKey),
+        );
+        expect(target.top, greaterThanOrEqualTo(viewport.top));
+        expect(target.bottom, lessThanOrEqualTo(viewport.bottom));
+      },
+    );
+  }
 }
 
 Widget _testApp(Widget child) {
@@ -201,4 +256,72 @@ class _BidirectionalHistoryPrototypeState
       ),
     );
   }
+}
+
+class _TargetedHistoryPrototype extends StatefulWidget {
+  const _TargetedHistoryPrototype({
+    super.key,
+    required this.controller,
+    required this.cacheExtent,
+  });
+
+  static const targetIndex = 50;
+  static const staleEstimate = targetIndex * 60.0;
+  static const scrollViewKey = ValueKey('targeted-history-scroll-view');
+  static const targetKey = ValueKey('targeted-history-message-50');
+
+  final ScrollController controller;
+  final double cacheExtent;
+
+  @override
+  State<_TargetedHistoryPrototype> createState() =>
+      _TargetedHistoryPrototypeState();
+}
+
+class _TargetedHistoryPrototypeState extends State<_TargetedHistoryPrototype> {
+  final _centerSliverKey = GlobalKey();
+  final _targetContextKey = GlobalKey();
+  var _pivotIndex = 0;
+
+  BuildContext? get targetContext => _targetContextKey.currentContext;
+
+  void stageTargetAtCenter() {
+    widget.controller.jumpTo(0);
+    setState(() => _pivotIndex = _TargetedHistoryPrototype.targetIndex);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final older = List<int>.generate(_pivotIndex, (index) => index);
+    final newer = List<int>.generate(
+      80 - _pivotIndex,
+      (index) => index + _pivotIndex,
+    );
+    return CustomScrollView(
+      key: _TargetedHistoryPrototype.scrollViewKey,
+      controller: widget.controller,
+      center: _centerSliverKey,
+      scrollCacheExtent: ScrollCacheExtent.pixels(widget.cacheExtent),
+      physics: const ClampingScrollPhysics(),
+      slivers: [
+        _messageSliver(older.reversed.toList(growable: false)),
+        _messageSliver(newer, key: _centerSliverKey),
+      ],
+    );
+  }
+
+  Widget _messageSliver(List<int> indexes, {Key? key}) => SliverList(
+    key: key,
+    delegate: SliverChildBuilderDelegate((context, localIndex) {
+      final messageIndex = indexes[localIndex];
+      final message = SizedBox(
+        key: ValueKey('targeted-history-message-$messageIndex'),
+        height: 300,
+        child: Text('message $messageIndex'),
+      );
+      return messageIndex == _TargetedHistoryPrototype.targetIndex
+          ? KeyedSubtree(key: _targetContextKey, child: message)
+          : message;
+    }, childCount: indexes.length),
+  );
 }

--- a/test/chat_scroll_metrics_test.dart
+++ b/test/chat_scroll_metrics_test.dart
@@ -374,6 +374,55 @@ void main() {
     expect(ensure, contains('!_isCurrentScrollTarget'));
   });
 
+  test('offscreen message navigation stages and settles the target', () {
+    final source = File('lib/chat/chat_view.dart').readAsStringSync();
+    final initialStart = source.indexOf(
+      'Future<void> _positionInitialTranscript()',
+    );
+    final initialEnd = source.indexOf(
+      'void _jumpToInitialEstimate()',
+      initialStart,
+    );
+    final initialPositioning = source.substring(initialStart, initialEnd);
+    expect(
+      initialPositioning,
+      contains('_stageMessageAtTranscriptCenter(initialTarget)'),
+    );
+
+    final ensureStart = source.indexOf(
+      'Future<bool> _ensureMessageVisibleAndReport(',
+    );
+    final ensureEnd = source.indexOf(
+      'Future<bool> _alignMessageTarget(',
+      ensureStart,
+    );
+    final ensure = source.substring(ensureStart, ensureEnd);
+    final stage = ensure.indexOf('_stageMessageAtTranscriptCenter(messageId)');
+    final frame = ensure.indexOf(
+      'await WidgetsBinding.instance.endOfFrame;',
+      stage,
+    );
+    expect(stage, greaterThanOrEqualTo(0));
+    expect(frame, greaterThan(stage));
+    expect(
+      ensure,
+      isNot(
+        contains('Future<void>.delayed(const Duration(milliseconds: 120))'),
+      ),
+    );
+
+    final alignStart = ensureEnd;
+    final alignEnd = source.indexOf(
+      'Future<bool> _alignPinnedMessage(',
+      alignStart,
+    );
+    final align = source.substring(alignStart, alignEnd);
+    expect(align, contains('for (var pass = 0; pass < 3; pass++)'));
+    expect(align, contains('await Scrollable.ensureVisible('));
+    expect(align, contains('await WidgetsBinding.instance.endOfFrame;'));
+    expect(align, contains('const Duration(milliseconds: 80)'));
+  });
+
   test('short transcript positioning is awaited and cancelable', () {
     final source = File('lib/chat/chat_view.dart').readAsStringSync();
     expect(


### PR DESCRIPTION
## Problem

Closes #64.

Search jumps reused one static row-height estimate up to six times. When long text, previews, reactions, or media made the accumulated error larger than the scroll cache (260 px on Android and 420 px on iOS), the target row never entered the build range and every retry landed at the same wrong offset. iOS shared the same failure mode, with a larger cache only making it less frequent.

## Changes

- Rebase the bidirectional transcript pivot around an offscreen target so the target is built on the next frame without relying on accumulated height estimates.
- Use the same staging path for cold initial message targets.
- Replace fixed 120 ms retries with frame-synchronized layout waits.
- Keep the target key through three alignment passes so rich content settling cannot leave the message displaced.
- Add regression coverage for Android and iOS cache extents under a 5x row-height underestimate.

## Tests

- `flutter test --no-pub test/chat_bidirectional_sliver_anchor_test.dart test/transcript_pivot_partition_test.dart test/chat_view_update_coalescing_test.dart test/chat_search_navigation_test.dart test/desktop_inline_search_navigation_test.dart test/chat_session_scroll_restore_test.dart test/chat_open_performance_test.dart test/chat_message_search_test.dart test/chat_unread_progress_test.dart test/chat_auto_scroll_policy_test.dart test/chat_return_to_latest_coordinator_test.dart` (172 passed)
- `flutter test --no-pub test/chat_scroll_metrics_test.dart --name 'loaded message jumps|message navigation owns|offscreen message navigation'` (3 passed)
- `flutter analyze --no-pub` (no errors or warnings from this change; one pre-existing info in `test/rich_text_text_scaler_test.dart:21`)