### PR TITLE
Keep page headers clear of iPadOS floating window controls

### DIFF
--- a/lib/app/ipad_window_chrome.dart
+++ b/lib/app/ipad_window_chrome.dart
@@ -1,0 +1,101 @@
+//
+//  ipad_window_chrome.dart
+//
+//  iPadOS 26 draws persistent traffic-light window controls over the top-left
+//  corner of floating windows while reporting no matching safe-area inset.
+//  This helper reserves extra top clearance so headers keep their leading
+//  content (e.g. the chat-list avatar) below the controls.
+//
+
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+/// Extra top inset, in logical pixels, reserved for the iPadOS window
+/// controls shown over the top-left corner of a floating window.
+const double iPadWindowControlsTopInset = 40;
+
+/// First iPadOS major version that shows the traffic-light window controls.
+const int _windowControlsMinimumMajorVersion = 26;
+
+/// Comparison tolerance, in physical pixels, for the floating-window check.
+const double _sizeTolerance = 2;
+
+final RegExp _versionPattern = RegExp(r'Version (\d+)');
+
+int? _cachedHostMajorVersion;
+
+/// Extra top inset that clears the iPadOS window controls for the view
+/// owning [context]; returns 0 whenever the controls are not shown.
+double iPadWindowChromeInsetOf(BuildContext context) {
+  final view = View.of(context);
+  return iPadWindowChromeInset(
+    viewSize: view.physicalSize,
+    displaySize: view.display.size,
+    paddingTop: MediaQuery.of(context).padding.top,
+  );
+}
+
+/// Pure variant of [iPadWindowChromeInsetOf].
+///
+/// The controls only exist on iPadOS 26+ floating windows; fullscreen
+/// windows and every other platform keep a zero inset. Two signals detect
+/// a floating window:
+///
+/// * The view is smaller than its display in both dimensions. Sizes are
+///   compared orientation-independent because `Display.size` keeps the
+///   panel's native portrait orientation while `FlutterView.physicalSize`
+///   follows the current interface orientation.
+/// * The top safe-area inset is the small window-chrome margin (~10pt)
+///   instead of the fullscreen menu-bar inset (~32pt). iPhone landscape
+///   reports 0 there, so only a strictly positive inset counts.
+double iPadWindowChromeInset({
+  required Size viewSize,
+  required Size displaySize,
+  required double paddingTop,
+  TargetPlatform? platform,
+  bool isWeb = kIsWeb,
+  String? operatingSystemVersion,
+}) {
+  if (isWeb) return 0;
+  if ((platform ?? defaultTargetPlatform) != TargetPlatform.iOS) return 0;
+  if (!_supportsWindowControls(operatingSystemVersion)) return 0;
+  final floating = paddingTop > 0 && paddingTop <= 16 ||
+      _isSmallerInBothDimensions(viewSize, displaySize);
+  return floating ? iPadWindowControlsTopInset : 0;
+}
+
+bool _isSmallerInBothDimensions(Size size, Size other) {
+  final sides = [size.width, size.height]..sort();
+  final otherSides = [other.width, other.height]..sort();
+  return sides[0] < otherSides[0] - _sizeTolerance &&
+      sides[1] < otherSides[1] - _sizeTolerance;
+}
+
+bool _supportsWindowControls(String? operatingSystemVersion) {
+  final major = operatingSystemVersion == null
+      ? _hostMajorVersion()
+      : _parseMajorVersion(operatingSystemVersion);
+  return major != null && major >= _windowControlsMinimumMajorVersion;
+}
+
+int? _hostMajorVersion() {
+  return _cachedHostMajorVersion ??= _parseMajorVersion(
+    _safeOperatingSystemVersion(),
+  );
+}
+
+String _safeOperatingSystemVersion() {
+  try {
+    return Platform.operatingSystemVersion;
+  } catch (_) {
+    return '';
+  }
+}
+
+int? _parseMajorVersion(String operatingSystemVersion) {
+  final match = _versionPattern.firstMatch(operatingSystemVersion);
+  if (match == null) return null;
+  return int.tryParse(match.group(1)!);
+}

--- a/lib/auth/login_view.dart
+++ b/lib/auth/login_view.dart
@@ -18,6 +18,7 @@ import 'package:provider/provider.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../app/ipad_window_chrome.dart';
 import '../bot_api/bot_api_account.dart';
 import '../bot_api/bot_api_client.dart';
 import '../bot_api/bot_api_endpoint_config.dart';
@@ -288,7 +289,9 @@ class _LoginViewState extends State<LoginView> {
             ),
             if (canGoBack)
               Positioned(
-                top: MediaQuery.of(context).padding.top + 6,
+                top: MediaQuery.of(context).padding.top +
+                    iPadWindowChromeInsetOf(context) +
+                    6,
                 left: 6,
                 child: AppInteractiveSurface(
                   semanticLabel: AppStringKeys.navigationBack.l10n(context),
@@ -313,7 +316,9 @@ class _LoginViewState extends State<LoginView> {
                 ),
               ),
             Positioned(
-              top: MediaQuery.of(context).padding.top + 6,
+              top: MediaQuery.of(context).padding.top +
+                  iPadWindowChromeInsetOf(context) +
+                  6,
               right: 6,
               child: _topRightActions(auth, showingPhone),
             ),

--- a/lib/channels/topic_chat_view.dart
+++ b/lib/channels/topic_chat_view.dart
@@ -12,6 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../app/app_navigator.dart';
+import '../app/ipad_window_chrome.dart';
 import '../chat/chat_members_view.dart';
 import '../chat/chat_picker_view.dart';
 import '../chat/chat_view.dart';
@@ -1054,7 +1055,8 @@ class _TopicChatViewState extends State<TopicChatView> {
 
   Widget _header() {
     final c = context.colors;
-    final top = MediaQuery.of(context).padding.top;
+    final top = MediaQuery.of(context).padding.top +
+        iPadWindowChromeInsetOf(context);
     final title = widget.chat.isBotTopicChat
         ? widget.chat.title
         : context.watch<GroupRemarkController?>()?.displayTitleFor(

--- a/lib/chat/add_members_view.dart
+++ b/lib/chat/add_members_view.dart
@@ -8,6 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:mithka/l10n/app_localizations.dart';
 
+import '../app/ipad_window_chrome.dart';
 import '../components/app_icons.dart';
 import '../components/photo_avatar.dart';
 import '../components/toast.dart';
@@ -114,7 +115,10 @@ class _AddMembersViewState extends State<AddMembersView> {
     final c = context.colors;
     final canAdd = _selected.isNotEmpty && !_adding;
     return Container(
-      padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top +
+            iPadWindowChromeInsetOf(context),
+      ),
       decoration: BoxDecoration(
         color: c.navBar,
         border: Border(bottom: BorderSide(color: c.divider, width: 0.5)),

--- a/lib/chat/audio_search_view.dart
+++ b/lib/chat/audio_search_view.dart
@@ -11,6 +11,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:mithka/l10n/app_localizations.dart';
 
+import '../app/ipad_window_chrome.dart';
 import '../components/app_icons.dart';
 import '../components/photo_avatar.dart';
 import '../components/toast.dart';
@@ -232,7 +233,10 @@ class _AudioSearchViewState extends State<AudioSearchView> {
   Widget _header() {
     final c = context.colors;
     return Container(
-      padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top +
+            iPadWindowChromeInsetOf(context),
+      ),
       decoration: BoxDecoration(
         color: c.navBar,
         border: Border(bottom: BorderSide(color: c.divider, width: 0.5)),

--- a/lib/chat/chat_message_search_bar.dart
+++ b/lib/chat/chat_message_search_bar.dart
@@ -13,6 +13,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../app/ipad_window_chrome.dart';
 import '../chats/search_token_views.dart';
 import '../components/app_icons.dart';
 import '../components/app_interactive_surface.dart';
@@ -58,7 +59,10 @@ class ChatSearchHeaderBar extends StatelessWidget {
     final c = context.colors;
     return Container(
       key: const ValueKey('chatSearchHeader'),
-      padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top +
+            iPadWindowChromeInsetOf(context),
+      ),
       decoration: BoxDecoration(
         color: backgroundColor ?? c.navBar,
         border: showDivider

--- a/lib/chat/chat_picker_view.dart
+++ b/lib/chat/chat_picker_view.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:mithka/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 
+import '../app/ipad_window_chrome.dart';
 import '../chats/chat_list_view_model.dart';
 import '../components/app_icons.dart';
 import '../components/photo_avatar.dart';
@@ -220,7 +221,10 @@ class _ChatPickerViewState extends State<ChatPickerView> {
   Widget _header() {
     final c = context.colors;
     return Container(
-      padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top +
+            iPadWindowChromeInsetOf(context),
+      ),
       decoration: BoxDecoration(
         color: c.navBar,
         border: Border(bottom: BorderSide(color: c.divider, width: 0.5)),

--- a/lib/chat/chat_view.dart
+++ b/lib/chat/chat_view.dart
@@ -21,6 +21,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../app/active_conversation.dart';
 import '../app/adaptive_split_layout.dart';
 import '../app/desktop_video_window.dart';
+import '../app/ipad_window_chrome.dart';
 import '../app/primary_chat_launcher.dart';
 import '../app/video_split_controller.dart';
 import '../auth/telegram_country_names.dart';
@@ -7191,7 +7192,10 @@ class _ChatViewState extends State<ChatView> {
     final actionActive = _vm.hasActiveChatAction;
     final wideGroupHeader = _usesWideGroupHeader;
     return Container(
-      padding: EdgeInsets.only(top: MediaQuery.paddingOf(context).top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.paddingOf(context).top +
+            iPadWindowChromeInsetOf(context),
+      ),
       decoration: BoxDecoration(
         color: widget.headerColor ?? c.navBar,
         border: widget.showHeaderDivider
@@ -7492,7 +7496,10 @@ class _ChatViewState extends State<ChatView> {
     final c = context.colors;
     final count = _selectedMessageIds.length;
     return Container(
-      padding: EdgeInsets.only(top: MediaQuery.paddingOf(context).top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.paddingOf(context).top +
+            iPadWindowChromeInsetOf(context),
+      ),
       decoration: BoxDecoration(
         color: c.navBar,
         border: Border(bottom: BorderSide(color: c.divider, width: 0.5)),

--- a/lib/chat/full_image_viewer.dart
+++ b/lib/chat/full_image_viewer.dart
@@ -12,6 +12,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
+import '../app/ipad_window_chrome.dart';
 import '../app/macos_desktop_title_bar.dart';
 import '../components/app_icons.dart';
 import '../components/ui_components.dart';
@@ -112,7 +113,9 @@ class _FullImageViewerState extends State<FullImageViewer> {
             ),
           ),
           Positioned(
-            top: MediaQuery.of(context).padding.top + 8,
+            top: MediaQuery.of(context).padding.top +
+                iPadWindowChromeInsetOf(context) +
+                8,
             // The viewer covers the whole window, so on macOS the row would
             // otherwise sit under the traffic lights. Both sides move in by the
             // same clearance to keep the counter centred on the window.

--- a/lib/chat/group_management_log_view.dart
+++ b/lib/chat/group_management_log_view.dart
@@ -7,6 +7,7 @@
 import 'package:flutter/material.dart';
 import 'package:mithka/l10n/app_localizations.dart';
 
+import '../app/ipad_window_chrome.dart';
 import '../components/app_icons.dart';
 import '../components/photo_avatar.dart';
 import '../tdlib/json_helpers.dart';
@@ -121,7 +122,10 @@ class _GroupManagementLogViewState extends State<GroupManagementLogView> {
   Widget _header() {
     final c = context.colors;
     return Container(
-      padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top +
+            iPadWindowChromeInsetOf(context),
+      ),
       decoration: BoxDecoration(
         color: c.navBar,
         border: Border(bottom: BorderSide(color: c.divider, width: 0.5)),

--- a/lib/chat/pinned_messages_view.dart
+++ b/lib/chat/pinned_messages_view.dart
@@ -10,6 +10,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:mithka/l10n/app_localizations.dart';
 
+import '../app/ipad_window_chrome.dart';
 import '../app/primary_chat_launcher.dart';
 import '../components/app_icons.dart';
 import '../components/photo_avatar.dart';
@@ -124,7 +125,10 @@ class _PinnedMessagesViewState extends State<PinnedMessagesView> {
   Widget _header() {
     final c = context.colors;
     return Container(
-      padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top +
+            iPadWindowChromeInsetOf(context),
+      ),
       decoration: BoxDecoration(
         color: c.navBar,
         border: Border(bottom: BorderSide(color: c.divider, width: 0.5)),

--- a/lib/chat/shared_media_view.dart
+++ b/lib/chat/shared_media_view.dart
@@ -15,6 +15,7 @@ import 'package:mithka/l10n/app_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../app/adaptive_split_layout.dart';
+import '../app/ipad_window_chrome.dart';
 import '../app/primary_chat_launcher.dart';
 import '../chats/search_view.dart';
 import '../components/app_icons.dart';
@@ -947,7 +948,10 @@ class _SharedMediaViewState extends State<SharedMediaView> {
     final c = context.colors;
     return Container(
       key: const ValueKey('shared-media-inner-header'),
-      padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top +
+            iPadWindowChromeInsetOf(context),
+      ),
       decoration: BoxDecoration(
         color: c.navBar,
         border: Border(bottom: BorderSide(color: c.divider, width: 0.5)),

--- a/lib/chat/video_player_view.dart
+++ b/lib/chat/video_player_view.dart
@@ -22,6 +22,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:video_player/video_player.dart';
 
 import '../app/app_navigator.dart';
+import '../app/ipad_window_chrome.dart';
 import '../app/video_split_controller.dart';
 import '../components/app_icons.dart';
 import '../components/app_interactive_surface.dart';
@@ -4379,7 +4380,9 @@ class _VideoPlayerViewState extends State<VideoPlayerView>
           ),
         ),
         PositionedDirectional(
-          top: MediaQuery.paddingOf(context).top + 6,
+          top: MediaQuery.paddingOf(context).top +
+              iPadWindowChromeInsetOf(context) +
+              6,
           start: 8,
           child: _roundIconButton(
             HeroAppIcons.chevronLeft,

--- a/lib/chats/chat_list_view.dart
+++ b/lib/chats/chat_list_view.dart
@@ -22,6 +22,7 @@ import '../app/adaptive_split_layout.dart';
 import '../app/app_navigator.dart';
 import '../app/desktop_chat_list_title_bar_anchors.dart';
 import '../app/desktop_chat_window.dart';
+import '../app/ipad_window_chrome.dart';
 import '../auth/account_store.dart';
 import '../auth/auth_manager.dart';
 import '../channels/forum_topic_browser_view.dart';
@@ -1738,7 +1739,10 @@ class _ChatListViewState extends State<ChatListView>
     final activeFilter = _model.selectedFilter;
     return Container(
       color: c.listHeaderTint,
-      padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top +
+            iPadWindowChromeInsetOf(context),
+      ),
       child: Padding(
         padding: const EdgeInsets.symmetric(
           horizontal: AppSpacing.xxl,

--- a/lib/chats/search_view.dart
+++ b/lib/chats/search_view.dart
@@ -14,6 +14,7 @@ import 'package:mithka/l10n/app_localizations.dart';
 
 import '../app/active_conversation.dart';
 import '../app/app_navigator.dart';
+import '../app/ipad_window_chrome.dart';
 import '../app/primary_chat_launcher.dart';
 import '../chat/chat_search_query.dart';
 import '../chat/chat_search_view.dart';
@@ -1525,7 +1526,10 @@ class _SearchViewState extends State<SearchView> {
   Widget _header() {
     final c = context.colors;
     return Container(
-      padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top +
+            iPadWindowChromeInsetOf(context),
+      ),
       decoration: BoxDecoration(
         color: c.listHeaderTint,
         border: Border(bottom: BorderSide(color: c.divider, width: 0.5)),

--- a/lib/components/ui_components.dart
+++ b/lib/components/ui_components.dart
@@ -12,6 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
+import '../app/ipad_window_chrome.dart';
 import '../l10n/app_localizations.dart';
 import '../platform/adaptive_platform.dart';
 import '../platform/system_ui.dart';
@@ -319,9 +320,14 @@ class NavHeader extends StatelessWidget {
       value: systemUiOverlayStyleForSurface(c.navBar),
       child: Container(
         constraints: BoxConstraints(
-          minHeight: headerHeight + MediaQuery.of(context).padding.top,
+          minHeight: headerHeight +
+              MediaQuery.of(context).padding.top +
+              iPadWindowChromeInsetOf(context),
         ),
-        padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+        padding: EdgeInsets.only(
+          top: MediaQuery.of(context).padding.top +
+              iPadWindowChromeInsetOf(context),
+        ),
         decoration: BoxDecoration(
           color: c.navBar,
           border: Border(

--- a/lib/contacts/add_people_view.dart
+++ b/lib/contacts/add_people_view.dart
@@ -13,6 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:mithka/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 
+import '../app/ipad_window_chrome.dart';
 import '../app/primary_chat_launcher.dart';
 import '../components/app_icons.dart';
 import '../components/icon_grid.dart';
@@ -279,7 +280,10 @@ class _AddPeopleViewState extends State<AddPeopleView> {
   Widget _header() {
     final c = context.colors;
     return Container(
-      padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top +
+            iPadWindowChromeInsetOf(context),
+      ),
       decoration: BoxDecoration(
         color: c.navBar,
         border: Border(bottom: BorderSide(color: c.divider, width: 0.5)),

--- a/lib/contacts/contacts_view.dart
+++ b/lib/contacts/contacts_view.dart
@@ -13,6 +13,7 @@ import 'package:mithka/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 
 import '../app/app_navigator.dart';
+import '../app/ipad_window_chrome.dart';
 import '../app/primary_chat_launcher.dart';
 import '../chat/chat_view.dart';
 import '../components/app_icons.dart';
@@ -269,7 +270,10 @@ class _ContactsViewState extends State<ContactsView> {
     return Container(
       key: const ValueKey('contacts-root-header'),
       color: c.listHeaderTint,
-      padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top +
+            iPadWindowChromeInsetOf(context),
+      ),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
         child: Row(

--- a/lib/contacts/create_group_view.dart
+++ b/lib/contacts/create_group_view.dart
@@ -10,6 +10,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:mithka/l10n/app_localizations.dart';
 
+import '../app/ipad_window_chrome.dart';
 import '../app/primary_chat_launcher.dart';
 import '../components/app_icons.dart';
 import '../components/photo_avatar.dart';
@@ -132,7 +133,10 @@ class _CreateGroupViewState extends State<CreateGroupView> {
     final c = context.colors;
     final canCreate = _selected.isNotEmpty && !_creating;
     return Container(
-      padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top +
+            iPadWindowChromeInsetOf(context),
+      ),
       decoration: BoxDecoration(
         color: c.navBar,
         border: Border(bottom: BorderSide(color: c.divider, width: 0.5)),

--- a/lib/moments/moments_view.dart
+++ b/lib/moments/moments_view.dart
@@ -16,6 +16,7 @@ import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
 
 import '../app/app_navigator.dart';
+import '../app/ipad_window_chrome.dart';
 import '../chat/chat_picker_view.dart';
 import '../chat/chat_view.dart';
 import '../chat/custom_emoji.dart';
@@ -2520,7 +2521,10 @@ class _ChannelMomentsSearchViewState extends State<ChannelMomentsSearchView> {
   Widget _header() {
     final c = context.colors;
     return Container(
-      padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top +
+            iPadWindowChromeInsetOf(context),
+      ),
       decoration: BoxDecoration(
         color: c.navBar,
         border: Border(bottom: BorderSide(color: c.divider, width: 0.5)),
@@ -3582,12 +3586,14 @@ class _ChannelPostComposerViewState extends State<ChannelPostComposerView> {
     final c = context.colors;
     return Container(
       padding: EdgeInsets.only(
-        top: MediaQuery.of(context).padding.top,
+        top: MediaQuery.of(context).padding.top +
+            iPadWindowChromeInsetOf(context),
         left: AppSpacing.xxl,
         right: AppSpacing.xxl,
       ),
-      height:
-          MediaQuery.of(context).padding.top + AppMetric.composerHeaderHeight,
+      height: MediaQuery.of(context).padding.top +
+          iPadWindowChromeInsetOf(context) +
+          AppMetric.composerHeaderHeight,
       color: c.groupedBackground,
       child: Row(
         children: [

--- a/lib/moments/short_video_view.dart
+++ b/lib/moments/short_video_view.dart
@@ -5,6 +5,7 @@ import 'package:mithka/l10n/app_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../app/app_navigator.dart';
+import '../app/ipad_window_chrome.dart';
 import '../chat/chat_picker_view.dart';
 import '../chat/chat_view.dart';
 import '../chat/video_player_view.dart';
@@ -540,7 +541,9 @@ class _ShortVideoViewState extends State<ShortVideoView> {
     return Positioned(
       left: 8,
       right: 8,
-      top: MediaQuery.paddingOf(context).top + 6,
+      top: MediaQuery.paddingOf(context).top +
+          iPadWindowChromeInsetOf(context) +
+          6,
       child: Row(
         children: [
           _roundButton(

--- a/lib/moments/story_viewer_view.dart
+++ b/lib/moments/story_viewer_view.dart
@@ -20,6 +20,7 @@ import 'package:mithka/l10n/app_localizations.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:video_player/video_player.dart';
 
+import '../app/ipad_window_chrome.dart';
 import '../app/primary_chat_launcher.dart';
 import '../chat/chat_picker_view.dart';
 import '../chat/custom_emoji.dart';
@@ -543,7 +544,8 @@ class _StoryViewerViewState extends State<StoryViewerView>
 
   @override
   Widget build(BuildContext context) {
-    final top = MediaQuery.of(context).padding.top;
+    final top = MediaQuery.of(context).padding.top +
+        iPadWindowChromeInsetOf(context);
     final desktop = storyViewerUsesDesktopControls(Theme.of(context).platform);
     final viewer = Scaffold(
       backgroundColor: Colors.black,

--- a/lib/profile/my_album_view.dart
+++ b/lib/profile/my_album_view.dart
@@ -10,6 +10,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:mithka/l10n/app_localizations.dart';
 
+import '../app/ipad_window_chrome.dart';
 import '../chat/image_preview.dart';
 import '../components/app_icons.dart';
 import '../components/photo_avatar.dart';
@@ -75,7 +76,10 @@ class _MyAlbumViewState extends State<MyAlbumView> {
   Widget _header() {
     final c = context.colors;
     return Container(
-      padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top +
+            iPadWindowChromeInsetOf(context),
+      ),
       decoration: BoxDecoration(
         color: c.navBar,
         border: Border(bottom: BorderSide(color: c.divider, width: 0.5)),

--- a/lib/profile/profile_detail_view.dart
+++ b/lib/profile/profile_detail_view.dart
@@ -19,6 +19,7 @@ import 'package:mithka/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 
 import '../app/desktop_image_preview_window.dart';
+import '../app/ipad_window_chrome.dart';
 import '../app/primary_chat_launcher.dart';
 import '../call/call_manager.dart';
 import '../chat/audio_search_view.dart';
@@ -724,7 +725,8 @@ class _ProfileDetailViewState extends State<ProfileDetailView> {
   /// Cover (blurred profile photo, gradient fallback) + overlapping avatar +
   /// name/username/status.
   Widget _header() {
-    final top = MediaQuery.of(context).padding.top;
+    final top = MediaQuery.of(context).padding.top +
+        iPadWindowChromeInsetOf(context);
     final bannerH = top + 232;
     final status = _isOnline
         ? AppStrings.t(AppStringKeys.presenceOnline)

--- a/lib/profile/profile_view.dart
+++ b/lib/profile/profile_view.dart
@@ -15,6 +15,7 @@ import 'package:flutter/material.dart';
 import 'package:mithka/l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 
+import '../app/ipad_window_chrome.dart';
 import '../app/primary_chat_launcher.dart';
 import '../auth/account_store.dart';
 import '../auth/auth_manager.dart';
@@ -277,7 +278,9 @@ class _ProfileViewState extends State<ProfileView> {
         Padding(
           padding: EdgeInsets.fromLTRB(
             20,
-            MediaQuery.of(context).padding.top + 8,
+            MediaQuery.of(context).padding.top +
+                iPadWindowChromeInsetOf(context) +
+                8,
             16,
             20,
           ),

--- a/lib/settings/settings_view.dart
+++ b/lib/settings/settings_view.dart
@@ -15,6 +15,7 @@ import 'package:provider/provider.dart';
 
 import '../app/adaptive_split_layout.dart';
 import '../app/app_version.dart';
+import '../app/ipad_window_chrome.dart';
 import '../auth/account_store.dart';
 import '../auth/auth_manager.dart';
 import '../components/app_icons.dart';
@@ -278,11 +279,13 @@ class _SettingsViewState extends State<SettingsView> {
   Widget _splitSidebarHeader(BuildContext context) {
     final c = context.colors;
     final desktopDense = !kIsWeb && isDesktopTargetPlatform();
+    // The enclosing SafeArea only clears the system inset; iPadOS floating
+    // windows additionally need clearance for the traffic-light controls.
     return Container(
       constraints: BoxConstraints(minHeight: desktopDense ? 48 : 58),
       padding: EdgeInsets.fromLTRB(
         desktopDense ? 14 : AppSpacing.lg,
-        desktopDense ? 8 : AppSpacing.md,
+        (desktopDense ? 8 : AppSpacing.md) + iPadWindowChromeInsetOf(context),
         desktopDense ? 14 : AppSpacing.lg,
         desktopDense ? 4 : AppSpacing.xs,
       ),

--- a/test/ipad_window_chrome_test.dart
+++ b/test/ipad_window_chrome_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mithka/app/ipad_window_chrome.dart';
+
+void main() {
+  // Values measured on an iPad Pro 13-inch simulator running iPadOS 27:
+  // Display.size always keeps the panel's native portrait orientation.
+  const displaySize = Size(2064, 2752);
+  const floatingViewSize = Size(2256, 1480);
+  const fullscreenViewSize = Size(2752, 2064);
+  const iPadOS26 = 'Version 26.0 (Build 23A5260n)';
+
+  test('reserves clearance for a floating window on iPadOS 26', () {
+    expect(
+      iPadWindowChromeInset(
+        viewSize: floatingViewSize,
+        displaySize: displaySize,
+        paddingTop: 10,
+        platform: TargetPlatform.iOS,
+        isWeb: false,
+        operatingSystemVersion: iPadOS26,
+      ),
+      iPadWindowControlsTopInset,
+    );
+  });
+
+  test('reserves clearance for a full-width tiled window', () {
+    expect(
+      iPadWindowChromeInset(
+        viewSize: const Size(2752, 2000),
+        displaySize: displaySize,
+        paddingTop: 10,
+        platform: TargetPlatform.iOS,
+        isWeb: false,
+        operatingSystemVersion: iPadOS26,
+      ),
+      iPadWindowControlsTopInset,
+    );
+  });
+
+  test('no clearance in landscape fullscreen despite the menu bar', () {
+    expect(
+      iPadWindowChromeInset(
+        viewSize: fullscreenViewSize,
+        displaySize: displaySize,
+        paddingTop: 32,
+        platform: TargetPlatform.iOS,
+        isWeb: false,
+        operatingSystemVersion: iPadOS26,
+      ),
+      0,
+    );
+  });
+
+  test('no clearance in portrait fullscreen', () {
+    expect(
+      iPadWindowChromeInset(
+        viewSize: displaySize,
+        displaySize: displaySize,
+        paddingTop: 32,
+        platform: TargetPlatform.iOS,
+        isWeb: false,
+        operatingSystemVersion: iPadOS26,
+      ),
+      0,
+    );
+  });
+
+  test('no clearance on a landscape iPhone without a status bar', () {
+    expect(
+      iPadWindowChromeInset(
+        viewSize: const Size(2532, 1170),
+        displaySize: const Size(1170, 2532),
+        paddingTop: 0,
+        platform: TargetPlatform.iOS,
+        isWeb: false,
+        operatingSystemVersion: iPadOS26,
+      ),
+      0,
+    );
+  });
+
+  test('no clearance for a floating window before iPadOS 26', () {
+    expect(
+      iPadWindowChromeInset(
+        viewSize: floatingViewSize,
+        displaySize: displaySize,
+        paddingTop: 10,
+        platform: TargetPlatform.iOS,
+        isWeb: false,
+        operatingSystemVersion: 'Version 18.2 (Build 22C152)',
+      ),
+      0,
+    );
+  });
+
+  test('no clearance on other platforms', () {
+    for (final platform in const [
+      TargetPlatform.macOS,
+      TargetPlatform.android,
+      TargetPlatform.linux,
+      TargetPlatform.windows,
+      TargetPlatform.fuchsia,
+    ]) {
+      expect(
+        iPadWindowChromeInset(
+          viewSize: floatingViewSize,
+          displaySize: displaySize,
+          paddingTop: 10,
+          platform: platform,
+          isWeb: false,
+          operatingSystemVersion: iPadOS26,
+        ),
+        0,
+      );
+    }
+  });
+
+  test('no clearance on the web', () {
+    expect(
+      iPadWindowChromeInset(
+        viewSize: floatingViewSize,
+        displaySize: displaySize,
+        paddingTop: 10,
+        platform: TargetPlatform.iOS,
+        isWeb: true,
+        operatingSystemVersion: iPadOS26,
+      ),
+      0,
+    );
+  });
+
+  test('unparseable version string falls back to no clearance', () {
+    expect(
+      iPadWindowChromeInset(
+        viewSize: floatingViewSize,
+        displaySize: displaySize,
+        paddingTop: 10,
+        platform: TargetPlatform.iOS,
+        isWeb: false,
+        operatingSystemVersion: 'iOS',
+      ),
+      0,
+    );
+  });
+
+  test('size tolerance ignores sub-pixel rounding', () {
+    expect(
+      iPadWindowChromeInset(
+        viewSize: const Size(2063, 2751),
+        displaySize: displaySize,
+        paddingTop: 32,
+        platform: TargetPlatform.iOS,
+        isWeb: false,
+        operatingSystemVersion: iPadOS26,
+      ),
+      0,
+    );
+  });
+}


### PR DESCRIPTION
## Problem

On iPadOS 26+, apps running as floating windows get persistent traffic-light window controls drawn over the **top-left corner** of the Flutter view, with no matching safe-area inset reported. Top-anchored content (chat-list avatar, settings back chevron, search field, viewer close buttons, ...) renders underneath the controls.

## Root cause

- Header surfaces only padded by `MediaQuery.padding.top`, which is ~10pt in floating windows while the controls need ~40pt.
- `Display.size` keeps the panel's **native portrait** orientation (2064×2752) while `FlutterView.physicalSize` follows the current interface orientation, so naive width/height comparisons misfire in both directions (missed floating windows in landscape, false positives in fullscreen where the menu bar trims the height).

## Fix

New `lib/app/ipad_window_chrome.dart` helper, `iPadWindowChromeInsetOf(context)`, returning a 40pt top inset only when **all** of these hold:

1. `TargetPlatform.iOS`, non-web
2. iPadOS 26+ (parsed from `Platform.operatingSystemVersion`; older systems keep split-view layouts untouched)
3. The window is floating, detected by either signal:
   - view is smaller than its display in both dimensions, compared **orientation-independently** (sorted sides), or
   - top safe-area inset is the small window-chrome margin (`0 < top ≤ 16`) instead of the fullscreen menu-bar inset (~32pt) — covers full-width tiled windows; iPhone landscape reports 0 and is unaffected

Applied to every top-anchored header: chat list, search, `NavHeader` (all settings pages), settings split sidebar, chat/topic headers, contacts, profile, moments, login, and the image/story/video viewers. In fullscreen and on all other platforms the inset is 0, so behavior is unchanged.

Not covered: `app_asset_picker` top bar (third-party `wechat_assets_picker` bar; its height and hide-animation offset need coordinated changes — can be a follow-up).

## Tests

- `test/ipad_window_chrome_test.dart`: 10 cases over the floating/fullscreen/iPhone/pre-26/web/other-platform matrix, using values measured on an iPad Pro 13-inch iPadOS 27 simulator
- Manually verified on iPadOS 27 simulator: floating window clears the traffic lights on every touched page; fullscreen shows no extra gap