### PR TITLE
fix: never install a GTK header bar on Linux

### DIFF
--- a/lib/app/desktop_window_controls_io.dart
+++ b/lib/app/desktop_window_controls_io.dart
@@ -13,8 +13,10 @@ Future<void> configurePrimaryDesktopWindowChrome() async {
       windowButtonVisibility: false,
     );
   } on Object {
-    // A portable runner may omit native window chrome support. In that case
-    // its normal title bar remains usable and the Flutter controls are no-ops.
+    // A portable runner may omit native window chrome support. On Windows the
+    // native title bar then stays up and remains usable. On Linux the runner
+    // already created the window undecorated, so there is no native chrome to
+    // fall back to and the caption buttons are the only way to drive it.
   }
 }
 

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -1,9 +1,6 @@
 #include "my_application.h"
 
 #include <flutter_linux/flutter_linux.h>
-#ifdef GDK_WINDOWING_X11
-#include <gdk/gdkx.h>
-#endif
 
 #include "flutter/generated_plugin_registrant.h"
 #include <multi_window_manager/multi_window_manager_plugin.h>
@@ -26,32 +23,28 @@ static void my_application_activate(GApplication* application) {
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
-  // Use a header bar when running in GNOME as this is the common style used
-  // by applications and is the setup most users will be using (e.g. Ubuntu
-  // desktop).
-  // If running on X and not using GNOME then just use a traditional title bar
-  // in case the window manager does more exotic layout, e.g. tiling.
-  // If running on Wayland assume the header bar will work (may need changing
-  // if future cases occur).
-  gboolean use_header_bar = TRUE;
-#ifdef GDK_WINDOWING_X11
-  GdkScreen* screen = gtk_window_get_screen(window);
-  if (GDK_IS_X11_SCREEN(screen)) {
-    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
-    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
-      use_header_bar = FALSE;
-    }
-  }
-#endif
-  if (use_header_bar) {
-    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
-    gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "Mithka");
-    gtk_header_bar_set_show_close_button(header_bar, TRUE);
-    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
-  } else {
-    gtk_window_set_title(window, "Mithka");
-  }
+  // Mithka paints its own title bar and caption buttons on Linux (see
+  // DesktopWindowControls), so this window has to be undecorated from the
+  // moment it is created.
+  //
+  // The stock runner installs a GtkHeaderBar whenever it cannot prove it is on
+  // a non-GNOME X11 session - which on Wayland is always, because the
+  // GDK_IS_X11_SCREEN guard never matches. Dart then takes the decoration back
+  // off during startup (setTitleBarStyle(hidden)). That costs a second
+  // geometry negotiation after the window is already on screen: the content
+  // area grows by the header bar height and GDK's CSD shadow extents drop to
+  // zero, so GTK asks the Flutter view to resize while the engine is still
+  // rendering its first frames.
+  //
+  // On Wayland that race does not settle. FlView gives up waiting ("Timed out
+  // waiting for OpenGL frame of size WxH (have W'xH')") and keeps the stale
+  // frame, so the Dart side goes on laying out against a viewport that is
+  // wider than the real window: the maximize and close buttons land past the
+  // right edge where they cannot be clicked, and the strip they should have
+  // covered is left unpainted. Never installing the header bar keeps one
+  // window size in play for the whole session.
+  gtk_window_set_title(window, "Mithka");
+  gtk_window_set_decorated(window, FALSE);
 
   gtk_window_set_default_size(window, 1280, 720);
 


### PR DESCRIPTION
## Symptom

The Flutter-drawn caption buttons (`- o x`) in the top right are unusable on Linux: clicks land nowhere, and part of the title bar strip paints as a flat grey or black block instead of the app background.

They are not "expanding" on hover. The window's *viewport* is larger than the window, and `DesktopWindowControls` sits at the end of a `Row` that fills that viewport — so the maximize and close buttons are laid out past the real right edge, where nothing can click them, and the area the stale frame does not cover is left unpainted. Hovering just forces the repaint that makes it visible.

## Cause

`linux/runner/my_application.cc` was the stock runner, which only skips the header bar when it can prove it is on a non-GNOME **X11** session:

```c
gboolean use_header_bar = TRUE;
#ifdef GDK_WINDOWING_X11
  if (GDK_IS_X11_SCREEN(screen)) { ...; use_header_bar = FALSE; }
#endif
```

Under a native Wayland session `GDK_IS_X11_SCREEN` never matches, so the header bar is **always** installed. `main.dart:172` then calls `configurePrimaryDesktopWindowChrome()` → `setTitleBarStyle(hidden)`, which hides the header bar, undecorates the window, and zeroes GDK's CSD shadow extents (~26 px per side).

That is a second geometry negotiation *after* the window is already on screen, and it races the Flutter view's own resize. On Wayland the race does not settle — `FlView` gives up and keeps the stale frame:

```
Timed out waiting for OpenGL frame of size 1104x1408 (have 2560x1440)   <- 3.9s after launch
Timed out waiting for OpenGL frame of size  824x1400 (have  824x686)
```

`824x1400` is a 412x700 window at buffer scale 2; `have 824x686` is the previous size. The engine never produces a frame at the requested size, so Dart keeps laying out against the stale one.

Measured on a window pinned to 412 px wide: only the `-` glyph fell inside the window; `o` and `x` were laid out beyond the right edge.

## Fix

Create the window undecorated in the first place, so only one window size is ever in play:

```c
gtk_window_set_title(window, "Mithka");
gtk_window_set_decorated(window, FALSE);
```

Mithka draws its own title bar on Linux (`usesFlutterDesktopWindowControls` is true for Linux), so the GTK header bar was never wanted. The now-unused `gdk/gdkx.h` include goes with it. Core GTK3 only — no new dependency.

## Testing

Not built locally — no Flutter SDK on the machine this was diagnosed on. Diagnosis was done against the released 1.2.3 (285) Linux build under Hyprland/Wayland (`xwayland: False`, monitor scale 1.6 → GTK buffer scale 2). Needs a CI Linux build to confirm.

## Not covered

This is Wayland-specific and does **not** address the same report on Windows. The Windows path in `multi_window_manager` only does `DwmExtendFrameIntoClientArea` + `SWP_FRAMECHANGED`, and its `WM_NCHITTEST` never returns `HTMAXBUTTON`, so the Windows cause is still unidentified and left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVyGwypUasrDXqnb96ohwr