### PR TITLE
fix: run the caption buttons flush into the top right corner

### DIFF
--- a/lib/app/macos_desktop_title_bar.dart
+++ b/lib/app/macos_desktop_title_bar.dart
@@ -23,6 +23,9 @@ class MacosDesktopTitleBar extends StatelessWidget {
   static const double height = 40;
   static const double trafficLightLeadingClearance = 78;
   static const double identityGap = 12;
+
+  /// Trailing inset for the action row. Dropped when this bar carries the
+  /// window controls: a caption button has to reach the window corner.
   static const double trailingPadding = 12;
   static const double dividerWidth = 0.5;
 
@@ -89,12 +92,18 @@ class MacosDesktopTitleBar extends StatelessWidget {
               ),
               const SizedBox(width: 4),
             ],
+            // The caption buttons run flush into the top right corner, with
+            // no inset of their own. That is the shape Windows and Linux draw,
+            // and it is what puts close under the pointer when the window is
+            // maximized and the corner swallows the cursor. macOS keeps the
+            // inset because its controls are native and this slot is empty.
             if (trailingControls != null)
               KeyedSubtree(
                 key: const ValueKey('desktop-title-bar-window-controls'),
                 child: trailingControls,
-              ),
-            const SizedBox(width: trailingPadding),
+              )
+            else
+              const SizedBox(width: trailingPadding),
           ],
         ),
       ),

--- a/test/macos_desktop_title_bar_test.dart
+++ b/test/macos_desktop_title_bar_test.dart
@@ -110,6 +110,37 @@ void main() {
     },
   );
 
+  testWidgets('window controls reach the top right corner without a margin', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(extensions: [AppColors.light]),
+        home: const Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 600,
+            child: MacosDesktopTitleBar(
+              leadingClearance: 8,
+              appIdentity: SizedBox(width: 112, child: Text('Account')),
+              trailingControls: SizedBox(
+                key: ValueKey('test-window-controls'),
+                width: 138,
+                height: MacosDesktopTitleBar.height,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final corner = tester.getTopRight(
+      find.byKey(const ValueKey('test-window-controls')),
+    );
+    expect(corner.dx, 600);
+    expect(corner.dy, 0);
+  });
+
   testWidgets(
     'desktop title bar searches in place and hands Search All its query',
     (tester) async {


### PR DESCRIPTION
## Symptom

There is a gap to the right of the close button on Windows and Linux — the caption cluster stops ~12px short of the window's right edge instead of reaching the corner.

## Cause

`MacosDesktopTitleBar` appended its trailing inset unconditionally, after the window controls slot:

```dart
if (trailingControls != null)
  KeyedSubtree(
    key: const ValueKey('desktop-title-bar-window-controls'),
    child: trailingControls,
  ),
const SizedBox(width: trailingPadding),   // always added
```

The inset is right for the action row, but a caption button is supposed to own the corner. Besides looking wrong next to every other desktop app, it costs the corner target: with a maximized window you normally close it by throwing the pointer at the top right corner, and here that corner belonged to the gap rather than to close.

## Fix

Apply the inset only when the bar is *not* carrying window controls:

```dart
if (trailingControls != null)
  KeyedSubtree(...)
else
  const SizedBox(width: trailingPadding),
```

macOS is unaffected — its controls are native, `trailingControls` is null there, and it keeps the inset for the action row.

Vertically the buttons were already flush: `_CaptionButton.height` and `MacosDesktopTitleBar.height` are both 40, and the bottom divider is painted by a `DecoratedBox`, which does not inset its child.

## Testing

Added a regression test asserting the controls' top-right corner is exactly the bar's top-right corner (`dx == 600`, `dy == 0` for a 600px-wide bar).

Not run locally — there is no Dart/Flutter SDK on the machine this was written on, so CI is the first execution of this test.

## Note

Independent of #69, which fixes a Wayland-only viewport desync in the Linux runner. Different file, no conflict; either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVyGwypUasrDXqnb96ohwr