### PR TITLE
test: pin the title bar's trailing geometry on both paths

### DIFF
--- a/test/macos_desktop_title_bar_test.dart
+++ b/test/macos_desktop_title_bar_test.dart
@@ -52,6 +52,15 @@ void main() {
       find.byKey(const ValueKey('macos-account-identity')),
       findsOneWidget,
     );
+    // With no window controls the bar keeps its trailing inset, so the last
+    // element stops short of the right edge. macOS depends on that: its
+    // caption buttons are native and this slot is empty.
+    expect(
+      tester
+          .getTopRight(find.byKey(const ValueKey('macos-account-identity')))
+          .dx,
+      600 - MacosDesktopTitleBar.trailingPadding,
+    );
 
     final decoration = tester.widget<DecoratedBox>(
       find.byKey(const ValueKey('macos-desktop-title-bar-decoration')),
@@ -106,6 +115,16 @@ void main() {
               )
               .dx,
         ),
+      );
+      // The configuration Windows and Linux actually render: actions and
+      // controls together, with close still owning the corner.
+      expect(
+        tester
+            .getTopRight(
+              find.byKey(const ValueKey('desktop-title-bar-window-controls')),
+            )
+            .dx,
+        600,
       );
     },
   );

--- a/test/macos_desktop_title_bar_test.dart
+++ b/test/macos_desktop_title_bar_test.dart
@@ -52,9 +52,9 @@ void main() {
       find.byKey(const ValueKey('macos-account-identity')),
       findsOneWidget,
     );
-    // With no window controls the bar keeps its trailing inset, so the last
-    // element stops short of the right edge. macOS depends on that: its
-    // caption buttons are native and this slot is empty.
+    // With no window controls the bar keeps its trailing inset, so the
+    // account identity stops short of the right edge. macOS depends on that:
+    // its caption buttons are native and this slot is empty.
     expect(
       tester
           .getTopRight(find.byKey(const ValueKey('macos-account-identity')))


### PR DESCRIPTION
Follow-up to #70, closing the two coverage gaps its review identified.

## Why

#70 made the trailing inset conditional: applied when the bar has no window controls (macOS), skipped when it does (Windows/Linux). Only the second half got a test.

- **The macOS inset was unpinned.** Silently dropping it is the change's main regression risk, and the existing assertion in that test only requires `dragArea.width > 250`, which a 12px shift would not trip.
- **The actions + controls configuration was unpinned.** That is what Windows and Linux actually render. The test added in #70 omits `trailingActions`; the pre-existing test that has both only asserts their relative order (`actions.right < controls.left`), which holds with or without the inset.

## What

Two assertions, no production change.

**Test 1** (`appIdentity` + `accountIdentity`, no controls) — Row children are `78 + 112 + 12 + Expanded + 12 + 96 + 12`, so fixed width is 322, `Expanded` is 278, and the account identity spans 492→588:

```dart
expect(
  tester.getTopRight(find.byKey(const ValueKey('macos-account-identity'))).dx,
  600 - MacosDesktopTitleBar.trailingPadding,   // 588
);
```

Fails at 600 if the inset is ever dropped for the no-controls path.

**Portable chrome test** (actions + controls) — children are `8 + 112 + 12 + Expanded + 4 + 60 + 4 + 120`, fixed 320, `Expanded` 280, controls span 480→600:

```dart
expect(
  tester
      .getTopRight(find.byKey(const ValueKey('desktop-title-bar-window-controls')))
      .dx,
  600,
);
```

Fails at 588 against pre-#70 code, so it is discriminating rather than vacuous.

## Testing

Not run — still no Dart/Flutter SDK on this machine, so CI is the first execution. The figures above are hand-derived from the Row layout algorithm and were checked line-by-line by a reviewer that had no part in writing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVyGwypUasrDXqnb96ohwr