### PR TITLE
Keep a staged jump target from being rebased away

### DIFF
--- a/lib/chat/chat_view.dart
+++ b/lib/chat/chat_view.dart
@@ -2608,16 +2608,20 @@ class _ChatViewState extends State<ChatView> {
     // _isTranscriptShort walks every cached entry; nothing below moves the
     // scroll position or the pivot, so one measurement serves all three tests.
     final latestArmIsShort = _isTranscriptShort();
+    final hasPendingMessageTarget = _scrollTargetId != null;
     final hydratedShortTranscript = shouldRebaseForHydratedOlderPage(
       prependedOlder: prependedOlder,
       latestArmWasShort: latestArmIsShort,
       historyFillInFlight: _isFillingShortTranscript || _loadingOlderFromScroll,
       revealRequested: _revealLoadedOlderPage,
+      hasPendingMessageTarget: hasPendingMessageTarget,
     );
-    final followingLatest =
-        !_autoScrollPolicy.preservesViewport &&
-        !_maintainSessionScrollAnchor &&
-        !_transcriptViewportClaimedByUser;
+    final followingLatest = transcriptFollowsLatestEdge(
+      preservesViewport: _autoScrollPolicy.preservesViewport,
+      maintainsSessionAnchor: _maintainSessionScrollAnchor,
+      viewportClaimedByUser: _transcriptViewportClaimedByUser,
+      hasPendingMessageTarget: hasPendingMessageTarget,
+    );
     final hasMessageOlderThanPivot =
         _transcriptPivot != null &&
         _vm.messages.any(
@@ -8056,11 +8060,13 @@ class _ChatViewState extends State<ChatView> {
           pinnedJump: pinnedJump,
           isCancelled: targetCancelled,
         );
-        if (aligned && mounted && !targetCancelled()) {
-          setState(() => _setScrollTarget(null));
-          return true;
-        }
-        return false;
+        if (!mounted || targetCancelled()) return false;
+        // A correction pass can lose the row's context without the navigation
+        // being cancelled, and the jump is over either way. Holding the target
+        // past that point stalls new-message auto-scroll, short-transcript
+        // fill, and parked-pivot repair for as long as the chat stays open.
+        setState(() => _setScrollTarget(null));
+        return aligned;
       }
       if (!_scroll.hasClients) return false;
       // A loaded target can be arbitrarily far from the currently laid-out
@@ -8097,6 +8103,10 @@ class _ChatViewState extends State<ChatView> {
       if (isCancelled()) return false;
       final ctx = targetKey.currentContext;
       if (ctx == null || !ctx.mounted) return false;
+      // Nothing reflowed during the previous pass, so the remaining correction
+      // animations would only spend their duration re-issuing the offset the
+      // row already sits at.
+      if (pass > 0 && _isTargetAtAlignment(targetKey, alignment)) return true;
       await Scrollable.ensureVisible(
         ctx,
         alignment: alignment,
@@ -8113,6 +8123,22 @@ class _ChatViewState extends State<ChatView> {
       await WidgetsBinding.instance.endOfFrame;
     }
     return !isCancelled();
+  }
+
+  /// Whether the row already rests where `Scrollable.ensureVisible` would put
+  /// it, using the viewport's own reveal math so pinned slivers and oversized
+  /// rows are accounted for exactly as the real call accounts for them.
+  bool _isTargetAtAlignment(GlobalKey targetKey, double alignment) {
+    if (!_scroll.hasClients) return false;
+    final object = targetKey.currentContext?.findRenderObject();
+    if (object == null || !object.attached) return false;
+    final viewport = RenderAbstractViewport.maybeOf(object);
+    if (viewport == null) return false;
+    final target = clampScrollOffset(
+      _scroll.position,
+      viewport.getOffsetToReveal(object, alignment).offset,
+    );
+    return (target - _scroll.position.pixels).abs() <= 0.5;
   }
 
   /// Aligns a pinned target more than once because media rows can finish a

--- a/lib/chat/transcript_pivot_partition.dart
+++ b/lib/chat/transcript_pivot_partition.dart
@@ -35,17 +35,41 @@ bool shouldRebasePendingTranscriptPivot({
   return pivot?.cutoffMessageId == pendingOrderId && hasServerMessage;
 }
 
+/// Whether the transcript is still tracking its own latest edge.
+///
+/// A pending message target owns the viewport: selecting it already cancelled
+/// bottom-follow and anchor maintenance, and staging it rebases the pivot onto
+/// that row. Reporting "following latest" during that window lets an ordinary
+/// view-model notification — sender hydration, a read receipt, file progress —
+/// rebase the pivot straight back and strand the jump at the latest edge.
+bool transcriptFollowsLatestEdge({
+  required bool preservesViewport,
+  required bool maintainsSessionAnchor,
+  required bool viewportClaimedByUser,
+  required bool hasPendingMessageTarget,
+}) =>
+    !preservesViewport &&
+    !maintainsSessionAnchor &&
+    !viewportClaimedByUser &&
+    !hasPendingMessageTarget;
+
 /// Lets an older page fill a short visible transcript even when a touch froze
 /// its previous pivot while the request was in flight. Full transcripts retain
 /// their fixed pivot so ordinary pagination does not move the viewport.
+///
+/// [hasPendingMessageTarget] holds the reveal back for the same reason
+/// [transcriptFollowsLatestEdge] does: a hydrating older page must not discard
+/// a staged jump target before it has been aligned.
 bool shouldRebaseForHydratedOlderPage({
   required bool prependedOlder,
   required bool latestArmWasShort,
   required bool historyFillInFlight,
   required bool revealRequested,
+  bool hasPendingMessageTarget = false,
 }) =>
     prependedOlder &&
     latestArmWasShort &&
+    !hasPendingMessageTarget &&
     (historyFillInFlight || revealRequested);
 
 /// Whether the after-center arm is still too thin to treat as a filled

--- a/test/chat_bidirectional_sliver_anchor_test.dart
+++ b/test/chat_bidirectional_sliver_anchor_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mithka/chat/transcript_pivot_partition.dart';
 
 void main() {
   testWidgets(
@@ -154,7 +155,10 @@ void main() {
 
         final targetContext = historyKey.currentState!.targetContext;
         expect(targetContext, isNotNull);
-        await Scrollable.ensureVisible(targetContext!, alignment: 0.38);
+        await Scrollable.ensureVisible(
+          targetContext!,
+          alignment: _TargetedHistoryPrototype.alignment,
+        );
         await tester.pump();
 
         final viewport = tester.getRect(
@@ -165,6 +169,30 @@ void main() {
         );
         expect(target.top, greaterThanOrEqualTo(viewport.top));
         expect(target.bottom, lessThanOrEqualTo(viewport.bottom));
+        // #64 is a landing-offset bug, not a visibility bug: the row has to
+        // come to rest where the alignment asked for it, which is the offset
+        // RenderViewport.getOffsetToReveal computes from the free space around
+        // the row rather than from the whole viewport.
+        expect(
+          target.top - viewport.top,
+          closeTo(
+            (viewport.height - target.height) *
+                _TargetedHistoryPrototype.alignment,
+            0.5,
+          ),
+        );
+
+        // Staging moves the zero coordinate, not the transcript order: the
+        // row before the cutoff still ends exactly where the target begins.
+        final older = tester.getRect(
+          find.byKey(
+            const ValueKey(
+              'targeted-history-message-'
+              '${_TargetedHistoryPrototype.targetIndex - 1}',
+            ),
+          ),
+        );
+        expect(older.bottom, closeTo(target.top, 0.5));
       },
     );
   }
@@ -266,6 +294,9 @@ class _TargetedHistoryPrototype extends StatefulWidget {
   });
 
   static const targetIndex = 50;
+  static const messageCount = 80;
+  static const messageHeight = 300.0;
+  static const alignment = 0.38;
   static const staleEstimate = targetIndex * 60.0;
   static const scrollViewKey = ValueKey('targeted-history-scroll-view');
   static const targetKey = ValueKey('targeted-history-message-50');
@@ -281,21 +312,36 @@ class _TargetedHistoryPrototype extends StatefulWidget {
 class _TargetedHistoryPrototypeState extends State<_TargetedHistoryPrototype> {
   final _centerSliverKey = GlobalKey();
   final _targetContextKey = GlobalKey();
-  var _pivotIndex = 0;
+  TranscriptPivot? _pivot;
 
   BuildContext? get targetContext => _targetContextKey.currentContext;
 
+  /// Mirrors `_ChatViewState._stageMessageAtTranscriptCenter`: rebase the pivot
+  /// onto the target row, then return to the scroll view's zero coordinate,
+  /// which is the center sliver's leading edge by definition.
   void stageTargetAtCenter() {
     widget.controller.jumpTo(0);
-    setState(() => _pivotIndex = _TargetedHistoryPrototype.targetIndex);
+    setState(() {
+      _pivot = const TranscriptPivot(_TargetedHistoryPrototype.targetIndex);
+    });
   }
 
   @override
   Widget build(BuildContext context) {
-    final older = List<int>.generate(_pivotIndex, (index) => index);
-    final newer = List<int>.generate(
-      80 - _pivotIndex,
-      (index) => index + _pivotIndex,
+    // Routed through the same helpers chat_view.dart uses, so a regression in
+    // the pivot resolution or partitioning fails here instead of passing
+    // against a parallel arrangement of the slivers.
+    final partition = partitionTranscriptAtPivot<int>(
+      entries: List<int>.generate(
+        _TargetedHistoryPrototype.messageCount,
+        (index) => index,
+      ),
+      pivot: resolveTranscriptPivot(
+        currentPivot: _pivot,
+        initialWindowLoaded: true,
+        firstMessageId: 0,
+      )!,
+      messageIdsOf: (index) => [index],
     );
     return CustomScrollView(
       key: _TargetedHistoryPrototype.scrollViewKey,
@@ -304,8 +350,10 @@ class _TargetedHistoryPrototypeState extends State<_TargetedHistoryPrototype> {
       scrollCacheExtent: ScrollCacheExtent.pixels(widget.cacheExtent),
       physics: const ClampingScrollPhysics(),
       slivers: [
-        _messageSliver(older.reversed.toList(growable: false)),
-        _messageSliver(newer, key: _centerSliverKey),
+        _messageSliver(
+          partition.beforePivot.reversed.toList(growable: false),
+        ),
+        _messageSliver(partition.pivotAndAfter, key: _centerSliverKey),
       ],
     );
   }
@@ -316,7 +364,7 @@ class _TargetedHistoryPrototypeState extends State<_TargetedHistoryPrototype> {
       final messageIndex = indexes[localIndex];
       final message = SizedBox(
         key: ValueKey('targeted-history-message-$messageIndex'),
-        height: 300,
+        height: _TargetedHistoryPrototype.messageHeight,
         child: Text('message $messageIndex'),
       );
       return messageIndex == _TargetedHistoryPrototype.targetIndex

--- a/test/transcript_pivot_partition_test.dart
+++ b/test/transcript_pivot_partition_test.dart
@@ -131,6 +131,121 @@ void main() {
         isFalse,
       );
     });
+
+    test('holds the reveal while a jump target is still being aligned', () {
+      expect(
+        shouldRebaseForHydratedOlderPage(
+          prependedOlder: true,
+          latestArmWasShort: true,
+          historyFillInFlight: true,
+          revealRequested: true,
+          hasPendingMessageTarget: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('transcriptFollowsLatestEdge', () {
+    test('follows the latest edge when nothing owns the viewport', () {
+      expect(
+        transcriptFollowsLatestEdge(
+          preservesViewport: false,
+          maintainsSessionAnchor: false,
+          viewportClaimedByUser: false,
+          hasPendingMessageTarget: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('yields the latest edge to a pending message target', () {
+      expect(
+        transcriptFollowsLatestEdge(
+          preservesViewport: false,
+          maintainsSessionAnchor: false,
+          viewportClaimedByUser: false,
+          hasPendingMessageTarget: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('yields the latest edge to each established viewport owner', () {
+      for (final owner in const ['preserved', 'anchored', 'claimed']) {
+        expect(
+          transcriptFollowsLatestEdge(
+            preservesViewport: owner == 'preserved',
+            maintainsSessionAnchor: owner == 'anchored',
+            viewportClaimedByUser: owner == 'claimed',
+            hasPendingMessageTarget: false,
+          ),
+          isFalse,
+          reason: '$owner must not report as following the latest edge',
+        );
+      }
+    });
+  });
+
+  group('a staged jump target survives routine hydration', () {
+    // Staging a search target near the newest end of the loaded window leaves a
+    // sub-three-entry after-center arm with older history already present. That
+    // is exactly the shape shouldRebaseParkedShortTranscriptPivot and
+    // shouldRebaseForExpandedInitialWindow rebase, so a sender hydration or a
+    // read receipt arriving mid-jump used to discard the staging and drop the
+    // transcript back at the latest edge before the row was ever aligned.
+    bool followsLatest({required bool hasPendingMessageTarget}) =>
+        transcriptFollowsLatestEdge(
+          preservesViewport: false,
+          maintainsSessionAnchor: false,
+          viewportClaimedByUser: false,
+          hasPendingMessageTarget: hasPendingMessageTarget,
+        );
+
+    test('parked-arm rebasing stands down while the jump is in flight', () {
+      expect(
+        shouldRebaseParkedShortTranscriptPivot(
+          pivotCutoffMessageId: 70,
+          latestArmIsShort: true,
+          hasMessageOlderThanPivot: true,
+          followingLatest: followsLatest(hasPendingMessageTarget: true),
+        ),
+        isFalse,
+      );
+    });
+
+    test('expanded-window rebasing stands down while the jump is in flight', () {
+      expect(
+        shouldRebaseForExpandedInitialWindow(
+          transcriptChanged: true,
+          latestArmIsShort: true,
+          hasMessageOlderThanPivot: true,
+          followingLatest: followsLatest(hasPendingMessageTarget: true),
+        ),
+        isFalse,
+      );
+    });
+
+    test('both resume rebasing once the target is released', () {
+      expect(
+        shouldRebaseParkedShortTranscriptPivot(
+          pivotCutoffMessageId: 70,
+          latestArmIsShort: true,
+          hasMessageOlderThanPivot: true,
+          followingLatest: followsLatest(hasPendingMessageTarget: false),
+        ),
+        isTrue,
+      );
+      expect(
+        shouldRebaseForExpandedInitialWindow(
+          transcriptChanged: true,
+          latestArmIsShort: true,
+          hasMessageOlderThanPivot: true,
+          followingLatest: followsLatest(hasPendingMessageTarget: false),
+        ),
+        isTrue,
+      );
+    });
   });
 
   group('isLatestTranscriptArmShort', () {


### PR DESCRIPTION
Follow-up to #67, which fixed #64 by rebasing the transcript pivot onto an offscreen jump target instead of guessing its offset. The mechanism is right; these are the holes in it that [my review](https://github.com/iebb/mithka/pull/67#issuecomment-5411830993) flagged.

## 1. A staged pivot could be rebased away mid-jump

`_transcriptPivotFrozen` only guards the last clause of `shouldResetParkedPivot`:

```dart
parkedShortArm || expandedInitialWindow || hydratedShortTranscript
  || (!_transcriptPivotFrozen && ...)
```

Staging a target near the newest end of the loaded window leaves a
sub-three-entry after-center arm (`isLatestTranscriptArmShort` returns true
below three entries) with older history already present — the exact shape
`shouldRebaseParkedShortTranscriptPivot` and `shouldRebaseForExpandedInitialWindow`
exist to rebase. Any view-model notification arriving mid-jump — sender
hydration, a read receipt, file progress, all common right after
`loadAroundMessage` — therefore called `_resetTranscriptPivot()` and dropped the
transcript back at the latest edge before the row was ever aligned.

All three predicates were missing one fact: a jump is in flight. Selecting a
target already cancels bottom-follow and anchor maintenance, so "following the
latest edge" was never true during that window. That is now
`transcriptFollowsLatestEdge` next to the predicates it feeds, rather than a
condition buried in the notification handler.

## 2. `_alignMessageTarget` could leak `_scrollTargetId`

Passes 1 and 2 return `false` when the row's context is lost *without* the
navigation being cancelled, and the caller returned false without releasing the
target. Before #67 the single-shot path always released it unless cancelled —
and cancellation means a new navigation already owns it, so there was no leak.

A stuck `_scrollTargetId` disables new-message auto-scroll (`shouldAutoScroll`
requires `_scrollTargetId == null`), blocks `_fillShortTranscript` and
`_repairParkedShortTranscriptPivot`, and leaves the row highlighted — for the
life of the chat. The target is now released whenever alignment ends
uncancelled, and the pass result becomes the return value instead of the
release condition.

## 3. Correction passes no longer animate for nothing

`_alignMessageTarget` ran all three passes unconditionally, so every offscreen
jump spent 220 + 80 + 80 ms even when nothing reflowed. It now stops once the
row rests at the requested alignment, mirroring the early exit
`_alignPinnedMessage` already has. The check uses the viewport's own
`getOffsetToReveal`, so pinned slivers and rows taller than the viewport are
measured exactly the way `Scrollable.ensureVisible` measures them — the
alignment is applied to the free space around the row, not to the whole
viewport.

## Coverage

#67's regression test built a prototype that *reimplemented* the pivot idea, so
it would have passed unchanged had `_stageMessageAtTranscriptCenter` been
deleted. It now routes through `partitionTranscriptAtPivot` and
`resolveTranscriptPivot` — the same helpers `chat_view.dart` calls — and asserts
the landing offset rather than mere visibility, since #64 is a positioning bug
("落点偏移"), not a visibility one. Verified by mutation: flipping the `<` in
`partitionTranscriptAtPivot` to `<=` now fails both platform cases, where before
it passed.

Point 1 is covered directly in `transcript_pivot_partition_test.dart`, including
the staged-jump shape that used to be rebased away and a check that rebasing
resumes once the target is released.

`ChatView` has no query-injection seam the way `TopicChatView` does, so point 2
remains covered only by the source-shape assertions in
`chat_scroll_metrics_test.dart`. Worth a seam later.

## Tests

- `flutter test --no-pub` — 2178 passed. The 4 failures (`macos_desktop_title_bar_test.dart`, `macos_release_configuration_test.dart`, `media_message_translation_test.dart` ×2) also fail on `master` and are unrelated.
- `flutter analyze --no-pub` — no new issues; the one pre-existing info in `test/rich_text_text_scaler_test.dart:21` remains.

## Still open, not addressed here

Opening a chat at the unread divider keeps #64's original failure mode:
`_correctInitialPosition`'s `firstUnread` branch calls
`_ensureKeyVisible(_unreadKey)`, which returns false when the divider was never
built, and `_positionInitialTranscript`'s three retries never reposition.
Staging only applies when `_scrollTargetId != null`, and `_estimatedMessageExtent`
still omits web previews and reactions (#64's own suggestion). Separate issue.
