### PR TITLE
Draw the picker's permission tip and video badge with owned icons

### DIFF
--- a/lib/media/app_asset_picker.dart
+++ b/lib/media/app_asset_picker.dart
@@ -870,6 +870,111 @@ class AppAssetPickerBuilderDelegate
     );
   }
 
+  /// Same story as [accessLimitedBottomTip]: the package stamps
+  /// `Icons.videocam` beside every video's duration, which without Material
+  /// Icons is a tofu box on each video thumbnail in the grid.
+  @override
+  Widget videoIndicator(BuildContext context, AssetEntity asset) {
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: Container(
+        width: double.maxFinite,
+        height: 26,
+        padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 2),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: AlignmentDirectional.bottomCenter,
+            end: AlignmentDirectional.topCenter,
+            colors: [theme.splashColor, Colors.transparent],
+          ),
+        ),
+        child: Row(
+          children: [
+            const AppIcon(
+              HeroAppIcons.solidFileVideo,
+              size: 20,
+              color: Colors.white,
+            ),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsetsDirectional.only(start: 4),
+                child: Text(
+                  textDelegate.durationIndicatorBuilder(
+                    Duration(seconds: asset.duration),
+                  ),
+                  maxLines: 1,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 15,
+                    decoration: TextDecoration.none,
+                  ),
+                  strutStyle: const StrutStyle(
+                    forceStrutHeight: true,
+                    height: 1.4,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// The package draws this banner with `Icons.warning` and
+  /// `Icons.keyboard_arrow_right`. Without Material Icons bundled those two
+  /// codepoints have no glyph and render as tofu boxes at either end of the
+  /// blue bar. Same layout and same tap target, project icons instead.
+  @override
+  Widget accessLimitedBottomTip(BuildContext context) {
+    final bottomPadding = hasBottomActions
+        ? 0.0
+        : MediaQuery.paddingOf(context).bottom;
+    return GestureDetector(
+      onTap: () {
+        Feedback.forTap(context);
+        PhotoManager.openSetting();
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: 10,
+        ).add(EdgeInsets.only(bottom: bottomPadding)),
+        height: permissionLimitedBarHeight + bottomPadding,
+        color: theme.primaryColor,
+        child: Row(
+          children: [
+            const SizedBox(width: 5),
+            AppIcon(
+              HeroAppIcons.triangleExclamation,
+              size: 24,
+              color: const Color(0xFFFFA726).withValues(alpha: 0.8),
+            ),
+            const SizedBox(width: 15),
+            Expanded(
+              child: Semantics(
+                label: semanticsTextDelegate.accessAllTip,
+                child: Text(
+                  textDelegate.accessAllTip,
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: theme.textTheme.bodySmall?.color,
+                    decoration: TextDecoration.none,
+                  ),
+                ),
+              ),
+            ),
+            AppIcon(
+              HeroAppIcons.chevronRight,
+              size: 20,
+              color: (theme.iconTheme.color ?? theme.colorScheme.onSurface)
+                  .withValues(alpha: 0.5),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Widget _sendOptionToggle(
     BuildContext context, {
     required Key key,

--- a/test/app_asset_picker_test.dart
+++ b/test/app_asset_picker_test.dart
@@ -118,6 +118,71 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('limited-access tip and video badge carry no Material glyphs', (
+    tester,
+  ) async {
+    final provider = DefaultAssetPickerProvider.forTest(
+      requestType: RequestType.common,
+      maxAssets: 10,
+    );
+    final delegate = AppAssetPickerBuilderDelegate(
+      provider: provider,
+      // The tip only exists while the OS granted partial access.
+      initialPermission: PermissionState.limited,
+      config: const AssetPickerConfig(maxAssets: 10),
+      locale: const Locale('en'),
+    );
+    addTearDown(delegate.dispose);
+    final video = AssetEntity(
+      id: '1',
+      typeInt: 2,
+      width: 100,
+      height: 100,
+      duration: 6,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(extensions: [AppColors.light]),
+        home: Builder(
+          builder: (context) => Column(
+            children: [
+              delegate.accessLimitedBottomTip(context),
+              SizedBox(
+                height: 60,
+                width: 60,
+                child: delegate.videoIndicator(context, video),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final glyphs = tester
+        .widgetList<Icon>(find.byType(Icon))
+        .map((icon) => icon.icon)
+        .whereType<IconData>();
+    expect(glyphs, isNotEmpty);
+    // The package reaches for Icons.warning, Icons.keyboard_arrow_right and
+    // Icons.videocam here. Mithka bundles no Material Icons font, so any that
+    // survive draw as tofu boxes.
+    expect(
+      glyphs.where((glyph) => glyph.fontFamily == 'MaterialIcons'),
+      isEmpty,
+      reason: 'a Material codepoint has no glyph to render',
+    );
+
+    final owned = tester
+        .widgetList<AppIcon>(find.byType(AppIcon))
+        .map((icon) => icon.icon);
+    expect(owned, contains(HeroAppIcons.triangleExclamation));
+    expect(owned, contains(HeroAppIcons.chevronRight));
+    expect(owned, contains(HeroAppIcons.solidFileVideo));
+    expect(find.text('00:06'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('preview header uses owned icons and the app text style', (
     tester,
   ) async {


### PR DESCRIPTION
## The bug

Two tofu boxes at either end of the picker's blue "limited access" bar.

Mithka sets `uses-material-design: false` and no dependency pulls the font back in — I confirmed `MaterialIcons` is absent from the built `FontManifest.json` (16 families, none of them Material). So every `Icon(Icons.*)` inside `wechat_assets_picker` resolves a private-use codepoint with no glyph behind it and draws as a box.

`AppAssetPickerBuilderDelegate` already replaces the header glyphs for exactly this reason — its class comment says so. Two more were still getting through:

| where | package draws | now |
|---|---|---|
| limited-access tip | `Icons.warning`, `Icons.keyboard_arrow_right` | `HeroAppIcons.triangleExclamation`, `HeroAppIcons.chevronRight` |
| video duration badge | `Icons.videocam` | `HeroAppIcons.solidFileVideo` |

The video one is on **every video thumbnail in the grid** — visible in the reported screenshot too, next to the `00:06` cell.

## The fix

Overrides `accessLimitedBottomTip` and `videoIndicator`, keeping the package's layout, colors and tap targets and swapping only the glyph.

## Test

The guard asserts what actually goes wrong rather than which icons were picked: no `IconData` in the rendered tree may come from the `MaterialIcons` family. Verified it fails without the fix — stashing the delegate change turns it red with `a Material codepoint has no glyph to render`.

`flutter analyze` clean; all 11 tests in `app_asset_picker_test.dart` pass.

## Left alone

The iCloud download indicators (`Icons.cloud_off` / `Icons.cloud_download_outlined`) are inside the grid item builder's `progressBuilder`. Reaching them means reimplementing that whole builder, so they are out of scope here — they only appear on iOS for assets not yet pulled from iCloud.
