### PR TITLE
Keep community unread badges from coming back

### DIFF
--- a/lib/chats/chat_list_view_model.dart
+++ b/lib/chats/chat_list_view_model.dart
@@ -645,9 +645,13 @@ class ChatListViewModel extends ChangeNotifier {
     if (chat.unreadCount <= 0 && !chat.isMarkedUnread) return;
     final previousUnread = chat.unreadCount;
     final previousMarked = chat.isMarkedUnread;
+    final previousLastReadInboxMessageId = chat.lastReadInboxMessageId;
     _mutate(chat.id, (s) {
       s.unreadCount = 0;
       s.isMarkedUnread = false;
+      if (s.lastMessageId > s.lastReadInboxMessageId) {
+        s.lastReadInboxMessageId = s.lastMessageId;
+      }
     });
     _resort();
 
@@ -663,6 +667,7 @@ class ChatListViewModel extends ChangeNotifier {
       _mutate(chat.id, (s) {
         s.unreadCount = previousUnread;
         s.isMarkedUnread = previousMarked;
+        s.lastReadInboxMessageId = previousLastReadInboxMessageId;
       });
       _resort();
     });
@@ -690,7 +695,6 @@ class ChatListViewModel extends ChangeNotifier {
       final fresh = TDParse.chat(raw);
       if (fresh == null) return;
       messageId = fresh.lastMessageId;
-      _map[chat.id] = fresh;
     }
     if (messageId <= 0) return;
     await _client.query({
@@ -871,11 +875,22 @@ class ChatListViewModel extends ChangeNotifier {
       case 'updateChatReadInbox':
         final id = update.int64('chat_id');
         if (id == null) return;
-        _mutate(
-          id,
-          (s) =>
-              s.unreadCount = update.integer('unread_count') ?? s.unreadCount,
-        );
+        _mutate(id, (s) {
+          final lastReadInboxMessageId = update.int64(
+            'last_read_inbox_message_id',
+          );
+          // A locally emitted read update can overtake an older TDLib snapshot.
+          // Read boundaries never move backwards, so ignore the stale pair
+          // instead of letting its unread count resurrect a cleared badge.
+          if (lastReadInboxMessageId != null &&
+              lastReadInboxMessageId < s.lastReadInboxMessageId) {
+            return;
+          }
+          if (lastReadInboxMessageId != null) {
+            s.lastReadInboxMessageId = lastReadInboxMessageId;
+          }
+          s.unreadCount = update.integer('unread_count') ?? s.unreadCount;
+        });
         _scheduleResort();
 
       case 'updateChatUnreadMentionCount':
@@ -1074,6 +1089,9 @@ class ChatListViewModel extends ChangeNotifier {
       final recency = _compareChatSnapshotRecency(summary, existing);
       if (recency < 0 || (preserveExistingIfNotNewer && recency == 0)) {
         return;
+      }
+      if (recency == 0) {
+        _preserveFresherReadState(summary, existing);
       }
     }
     if (_meId != null) summary.isSavedMessages = summary.peerUserId == _meId;
@@ -1496,6 +1514,24 @@ class ChatListViewModel extends ChangeNotifier {
       return candidate.date.compareTo(existing.date);
     }
     return candidate.lastMessageId.compareTo(existing.lastMessageId);
+  }
+
+  /// A `getChat` requested by the community catalogue can finish after the
+  /// chat has already been marked read. For the same last-message snapshot,
+  /// the furthest read boundary is authoritative; at an equal boundary the
+  /// smaller unread count reflects more read progress. A genuinely newer last
+  /// message bypasses this merge and is free to add unread messages normally.
+  static void _preserveFresherReadState(
+    ChatSummary candidate,
+    ChatSummary existing,
+  ) {
+    final existingIsFresher =
+        existing.lastReadInboxMessageId > candidate.lastReadInboxMessageId ||
+        (existing.lastReadInboxMessageId == candidate.lastReadInboxMessageId &&
+            existing.unreadCount < candidate.unreadCount);
+    if (!existingIsFresher) return;
+    candidate.lastReadInboxMessageId = existing.lastReadInboxMessageId;
+    candidate.unreadCount = existing.unreadCount;
   }
 
   static int _compare(ChatSummary a, ChatSummary b) {

--- a/lib/tdlib/td_models.dart
+++ b/lib/tdlib/td_models.dart
@@ -511,6 +511,7 @@ class ChatSummary {
     required this.lastMessageId,
     required this.date,
     required this.unreadCount,
+    this.lastReadInboxMessageId = 0,
     this.unreadMentionCount = 0,
     required this.order,
     required this.isMuted,
@@ -540,6 +541,7 @@ class ChatSummary {
   int lastMessageId;
   int date;
   int unreadCount;
+  int lastReadInboxMessageId;
   int unreadMentionCount;
   int order;
   bool isMuted;
@@ -1468,6 +1470,7 @@ abstract final class TDParse {
       lastMessageId: lastMessageId,
       date: date,
       unreadCount: unread,
+      lastReadInboxMessageId: chat.int64('last_read_inbox_message_id') ?? 0,
       unreadMentionCount: chat.integer('unread_mention_count') ?? 0,
       order: order,
       isMuted: muted,

--- a/test/chat_list_view_model_lifecycle_test.dart
+++ b/test/chat_list_view_model_lifecycle_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mithka/chats/chat_list_view_model.dart';
+import 'package:mithka/communities/community_models.dart';
 import 'package:mithka/tdlib/json_helpers.dart';
 
 void main() {
@@ -166,6 +167,74 @@ void main() {
     expect(model.chats.single.date, 20);
     expect(model.chats.single.order, 200);
   });
+
+  testWidgets(
+    'stale community snapshot cannot restore an unread badge after read',
+    (tester) async {
+      final model = ChatListViewModel(
+        membershipForTesting: (_, _) async => true,
+      );
+      addTearDown(model.dispose);
+
+      final staleUnreadSnapshot = _groupChat(
+        order: 100,
+        messageId: 10,
+        messageDate: 10,
+        text: 'community message',
+        unreadCount: 4,
+      );
+      await model.ingestRawChatForTesting(staleUnreadSnapshot);
+      model.applyUpdateForTesting({
+        '@type': 'updateChatReadInbox',
+        'chat_id': 42,
+        'last_read_inbox_message_id': 10,
+        'unread_count': 0,
+      });
+      await tester.pump(const Duration(milliseconds: 50));
+
+      model.applyUpdateForTesting({
+        '@type': 'updateChatReadInbox',
+        'chat_id': 42,
+        'last_read_inbox_message_id': 5,
+        'unread_count': 2,
+      });
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(model.chats.single.unreadCount, 0);
+
+      // A community catalogue getChat that started before the read update can
+      // return afterwards with the same last message and its old unread count.
+      await model.ingestRawChatForTesting(staleUnreadSnapshot);
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(model.chats.single.unreadCount, 0);
+      expect(model.chats.single.lastReadInboxMessageId, 10);
+      final community = CommunityGroupEntry(
+        community: CommunitySummary(
+          id: 7,
+          name: 'Community',
+          haveAccess: true,
+          isAdministrator: false,
+          canEditChatList: false,
+        ),
+        chats: model.chats,
+      );
+      expect(community.unreadCount, 0);
+
+      // A genuinely newer message still creates a new unread count.
+      await model.ingestRawChatForTesting(
+        _groupChat(
+          order: 200,
+          messageId: 20,
+          messageDate: 20,
+          text: 'new community message',
+          unreadCount: 1,
+          lastReadInboxMessageId: 10,
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(model.chats.single.unreadCount, 1);
+    },
+  );
 }
 
 Map<String, dynamic> _privateChat({
@@ -195,11 +264,15 @@ Map<String, dynamic> _groupChat({
   required int messageId,
   required int messageDate,
   required String text,
+  int unreadCount = 0,
+  int lastReadInboxMessageId = 0,
 }) => {
   '@type': 'chat',
   'id': 42,
   'title': 'Current group',
   'view_as_topics': true,
+  'unread_count': unreadCount,
+  'last_read_inbox_message_id': lastReadInboxMessageId,
   'type': {
     '@type': 'chatTypeSupergroup',
     'supergroup_id': 7,


### PR DESCRIPTION
## The bug

On iOS v1.2.6, every chat inside a community could be read while the community avatar still showed a non-zero unread badge.

Community catalogue hydration starts getChat calls for child chats. A request that began before the read can finish after updateChatReadInbox. Because _ingestRawChat replaced an equal-last-message ChatSummary wholesale, the old unread_count returned and CommunityGroupEntry summed it back into the avatar badge.

## The fix

ChatSummary now carries the TDLib last_read_inbox_message_id. Read updates cannot move that boundary backwards; local mark-read advances it optimistically and restores it together with the other optimistic state if the request fails.

For two snapshots of the same last message, the merge keeps the farther read boundary, or the smaller unread count when the boundary is equal. A genuinely newer last message still adds unread state normally. The forced-read fallback also uses getChat only to locate the last message ID instead of replacing current chat state.

## Regression coverage

The lifecycle test recreates the reported race through the real community unread aggregation:

- ingest a child chat with 4 unread messages
- apply the read boundary and clear the count
- reject an older read update and a late stale getChat snapshot
- assert both the child chat and community aggregate stay at zero
- ingest a genuinely newer unread message and assert the badge can return

## Verification

- flutter test test/chat_list_view_model_lifecycle_test.dart — 5 passed
- flutter test test/community_feature_test.dart — 12 passed
- combined targeted suite — 17 passed
- flutter analyze on the three changed files — no issues
- full flutter analyze — one pre-existing info at test/rich_text_text_scaler_test.dart:21, no new issues
- full flutter test --no-pub --reporter=json — the branch and clean master have the same 8 failures: 2 macOS configuration assertions and 6 tdjson artifact-installer tests; no new failures