### PR TITLE
fix: emoji store retry after load failure and image-edit cancel label

### DIFF
--- a/lib/chat/emoji_store.dart
+++ b/lib/chat/emoji_store.dart
@@ -90,7 +90,9 @@ class EmojiStore extends ChangeNotifier {
       }
       customPacks = result;
       notifyListeners();
-    } catch (_) {}
+    } catch (_) {
+      _loaded = false; // allow retry on next loadIfNeeded()
+    }
   }
 
   TdFileRef? _coverRef(Map<String, dynamic> info) {

--- a/lib/chat/image_edit_view.dart
+++ b/lib/chat/image_edit_view.dart
@@ -504,7 +504,7 @@ class _ImageEditViewState extends State<ImageEditView> {
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
-            child: Text(AppStrings.t(AppStringKeys.countryPickerCancel)),
+            child: Text(AppStrings.t(AppStringKeys.confirmCancel)),
           ),
           TextButton(
             onPressed: () => Navigator.of(context).pop(controller.text),


### PR DESCRIPTION
## Summary
- **chat/emoji_store**: `_loaded` is reset when fetching installed custom-emoji packs fails, so the next `loadIfNeeded()` retries instead of leaving the store permanently empty until app restart.
- **chat/image_edit_view**: the add-text dialog's cancel button used the country picker's cancel string; it now uses the shared `confirmCancel` key.

## Source
Ports #114 and #84.

## Verification
- `dart analyze lib` — no issues
- `flutter test` — all 2332 tests pass
- `dart format` gate clean
