### PR TITLE
Stream complete video HTTP ranges in bounded chunks

### DIFF
--- a/lib/chat/td_video_stream_server.dart
+++ b/lib/chat/td_video_stream_server.dart
@@ -84,12 +84,12 @@ class TdVideoStreamServer {
     TdVideoStreamQuery? query,
     String? fileName,
     String? mimeType,
-    int maxResponseBytes = _defaultMaxResponseBytes,
+    int readChunkBytes = _defaultReadChunkBytes,
     this.rangeWaitTimeout = const Duration(seconds: 45),
     this.rangePollInterval = const Duration(milliseconds: 100),
-  }) : assert(maxResponseBytes > 0),
+  }) : assert(readChunkBytes > 0),
        _query = query ?? TdClient.shared.query,
-       _maxResponseBytes = maxResponseBytes,
+       _readChunkBytes = readChunkBytes,
        _mimeType = _videoStreamMimeType(fileName, mimeType),
        _extension = _videoStreamExtension(
          fileName,
@@ -98,7 +98,7 @@ class TdVideoStreamServer {
 
   final int fileId;
   final TdVideoStreamQuery _query;
-  final int _maxResponseBytes;
+  final int _readChunkBytes;
   final String _mimeType;
   final String _extension;
   final Duration rangeWaitTimeout;
@@ -122,7 +122,7 @@ class TdVideoStreamServer {
   final Map<(int, int), Future<Map<String, dynamic>?>> _rangeDownloads = {};
 
   static const _chunkSize = 2 * 1024 * 1024;
-  static const _defaultMaxResponseBytes = 2 * 1024 * 1024;
+  static const _defaultReadChunkBytes = 2 * 1024 * 1024;
   static const _metadataTailSize = 4 * 1024 * 1024;
 
   Future<Uri?> start() async {
@@ -345,6 +345,14 @@ class TdVideoStreamServer {
         return;
       }
 
+      if (request.method == 'HEAD') {
+        // Range applies to GET only. A metadata probe describes the full file
+        // without waiting for any media bytes to be downloaded.
+        _writeRangeHeaders(request.response, 0, _total - 1, false);
+        await request.response.close();
+        return;
+      }
+
       final rangeHeader = request.headers.value(HttpHeaders.rangeHeader);
       final range = rangeHeader == null ? null : _requestedRange(rangeHeader);
       if (rangeHeader != null && range == null) {
@@ -355,22 +363,10 @@ class TdVideoStreamServer {
         return;
       }
       final (start, end) = range ?? (0, _total - 1);
-      if (request.method == 'HEAD') {
-        if (range == null) {
-          _writeRangeHeaders(request.response, start, end, false);
-        } else {
-          final boundedEnd = _boundedEnd(start, end);
-          _writeRangeHeaders(request.response, start, boundedEnd, true);
-        }
-        await request.response.close();
-        return;
-      }
-
-      final boundedEnd = _boundedEnd(start, end);
-      final partial = range != null || boundedEnd < _total - 1;
-      final bytes = await _loadRange(
+      var chunkEnd = _readChunkEnd(start, end);
+      var bytes = await _loadRange(
         start,
-        boundedEnd,
+        chunkEnd,
         isCancelled: () => requestFinished,
       );
       if (requestFinished) return;
@@ -382,8 +378,29 @@ class TdVideoStreamServer {
         );
         return;
       }
-      _writeRangeHeaders(request.response, start, boundedEnd, partial);
-      request.response.add(bytes);
+      // Bound each TDLib read, not the HTTP response. Native players can treat
+      // the end of a shortened response as EOF instead of requesting the next
+      // chunk, even when Content-Range advertises a larger file.
+      _writeRangeHeaders(request.response, start, end, range != null);
+      request.response.bufferOutput = false;
+      while (true) {
+        request.response.add(bytes!);
+        await request.response.flush();
+        if (chunkEnd == end || requestFinished || _closed) break;
+        final chunkStart = chunkEnd + 1;
+        chunkEnd = _readChunkEnd(chunkStart, end);
+        bytes = await _loadRange(
+          chunkStart,
+          chunkEnd,
+          isCancelled: () => requestFinished,
+        );
+        if (requestFinished) return;
+        if (bytes == null) {
+          // Keep the advertised length: closing an incomplete body must be a
+          // transport failure, not a successful response ending the video.
+          throw const HttpException('Video stream range is unavailable');
+        }
+      }
       await request.response.close();
     } catch (_) {
       // The player may cancel a range request after headers were sent. Do not
@@ -445,10 +462,8 @@ class TdVideoStreamServer {
     await request.response.close();
   }
 
-  int _boundedEnd(int start, int requestedEnd) => math.min(
-    requestedEnd,
-    math.min(_total - 1, start + _maxResponseBytes - 1),
-  );
+  int _readChunkEnd(int start, int requestedEnd) =>
+      math.min(requestedEnd, math.min(_total - 1, start + _readChunkBytes - 1));
 
   Future<void> _closeEmptyResponse(
     HttpResponse response,
@@ -484,10 +499,9 @@ class TdVideoStreamServer {
     }
   }
 
-  /// Loads the complete bounded response before committing its headers.
-  /// AVFoundation validates `Content-Length` strictly, so an unavailable or
-  /// truncated TDLib range must become an empty retryable response rather than
-  /// a short successful body.
+  /// Loads one complete read chunk without exposing sparse or truncated bytes.
+  /// The first chunk is validated before committing response headers so a
+  /// range miss can still become an empty retryable response.
   Future<List<int>?> _loadRange(
     int start,
     int end, {
@@ -515,7 +529,7 @@ class TdVideoStreamServer {
     if (parts.first.isEmpty) {
       final suffixLength = int.tryParse(parts[1]) ?? 0;
       if (suffixLength <= 0) return null;
-      start = math.max(0, _total - math.min(suffixLength, _maxResponseBytes));
+      start = math.max(0, _total - suffixLength);
       requestedEnd = _total - 1;
     } else {
       start = int.tryParse(parts.first) ?? -1;

--- a/test/video_stream_server_test.dart
+++ b/test/video_stream_server_test.dart
@@ -11,7 +11,7 @@ void main() {
     final fixture = await _VideoServerFixture.create(
       bytes: List<int>.generate(64, (index) => index),
       totalBytes: 4 * 1024 * 1024,
-      maxResponseBytes: 16,
+      readChunkBytes: 16,
       reportedReadableBytes: 2 * 1024 * 1024,
     );
     try {
@@ -45,24 +45,154 @@ void main() {
   });
 
   test(
-    'a large request without Range returns one bounded exact body',
+    'a request without Range streams the entire file across read chunks',
     () async {
       final fixture = await _VideoServerFixture.create(
         bytes: List<int>.generate(64, (index) => index),
-        totalBytes: 1000000,
-        maxResponseBytes: 16,
+        totalBytes: 64,
+        readChunkBytes: 16,
       );
       try {
         final response = await fixture.get();
         final body = await _readBody(response);
 
+        expect(response.statusCode, HttpStatus.ok);
+        expect(response.contentLength, 64);
+        expect(response.headers.value(HttpHeaders.contentRangeHeader), isNull);
+        expect(body, fixture.bytes);
+      } finally {
+        await fixture.close();
+      }
+    },
+  );
+
+  for (final (range, start, end) in [
+    ('bytes=0-', 0, 64),
+    ('bytes=20-', 20, 64),
+    ('bytes=8-55', 8, 56),
+    ('bytes=-40', 24, 64),
+  ]) {
+    test('$range returns the full requested span across read chunks', () async {
+      final fixture = await _VideoServerFixture.create(
+        bytes: List<int>.generate(64, (index) => index),
+        totalBytes: 64,
+        readChunkBytes: 16,
+      );
+      try {
+        final response = await fixture.get(range: range);
+
         expect(response.statusCode, HttpStatus.partialContent);
-        expect(response.contentLength, 16);
+        expect(response.contentLength, end - start);
         expect(
           response.headers.value(HttpHeaders.contentRangeHeader),
-          'bytes 0-15/1000000',
+          'bytes $start-${end - 1}/64',
         );
-        expect(body, List<int>.generate(16, (index) => index));
+        expect(await _readBody(response), fixture.bytes.sublist(start, end));
+      } finally {
+        await fixture.close();
+      }
+    });
+  }
+
+  test('HEAD reports the full file without downloading media bytes', () async {
+    late _ControlledRangeBackend backend;
+    final fixture = await _VideoServerFixture.create(
+      bytes: const [],
+      totalBytes: 64,
+      readChunkBytes: 16,
+      queryBuilder: (file) {
+        backend = _ControlledRangeBackend(file: file, totalBytes: 64);
+        return backend.query;
+      },
+    );
+    try {
+      for (final range in [null, 'bytes=20-']) {
+        final response = await fixture.getUri(
+          fixture.uri,
+          method: 'HEAD',
+          range: range,
+        );
+        expect(response.statusCode, HttpStatus.ok);
+        expect(response.contentLength, 64);
+        expect(response.headers.value(HttpHeaders.contentRangeHeader), isNull);
+        expect(await _readBody(response), isEmpty);
+      }
+      expect(backend.boundedRequests, isEmpty);
+      expect(backend.prefixOffsets, isEmpty);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test('one response waits for and streams successive TDLib chunks', () async {
+    late _ControlledRangeBackend backend;
+    final fixture = await _VideoServerFixture.create(
+      bytes: List<int>.generate(64, (index) => index),
+      totalBytes: 64,
+      readChunkBytes: 16,
+      queryBuilder: (file) {
+        backend = _ControlledRangeBackend(file: file, totalBytes: 64);
+        return backend.query;
+      },
+    );
+    try {
+      final pendingResponse = fixture.get(range: 'bytes=0-');
+      await _waitFor(() => backend.boundedRequests.isNotEmpty);
+      backend.completeBounded(0);
+      final response = await pendingResponse;
+      expect(response.contentLength, 64);
+
+      final received = <int>[];
+      var finished = false;
+      final body = response
+          .forEach(received.addAll)
+          .whenComplete(() => finished = true);
+      body.ignore();
+      await _waitFor(() => received.length == 16);
+      for (var index = 1; index < 4; index++) {
+        await _waitFor(() => backend.boundedRequests.length > index);
+        expect(backend.boundedRequests[index]['offset'], index * 16);
+        expect(backend.boundedRequests[index]['limit'], 16);
+        expect(received, fixture.bytes.sublist(0, index * 16));
+        expect(
+          finished,
+          isFalse,
+          reason: 'a read chunk is not the end of video',
+        );
+        backend.completeBounded(index);
+        await _waitFor(() => received.length == (index + 1) * 16);
+      }
+      await body;
+      expect(received, fixture.bytes);
+      expect(backend.unlimitedRequests, 0);
+    } finally {
+      await fixture.close();
+      for (var index = 0; index < backend.boundedRequests.length; index++) {
+        backend.completeBounded(index);
+      }
+    }
+  });
+
+  test(
+    'an unavailable later chunk interrupts the advertised full response',
+    () async {
+      final fixture = await _VideoServerFixture.create(
+        bytes: List<int>.generate(16, (index) => index),
+        totalBytes: 64,
+        readChunkBytes: 16,
+      );
+      try {
+        final response = await fixture.get(range: 'bytes=0-');
+        expect(response.contentLength, 64);
+        expect(
+          response.headers.value(HttpHeaders.contentRangeHeader),
+          'bytes 0-63/64',
+        );
+        await expectLater(_readBody(response), throwsA(isA<HttpException>()));
+
+        final retry = await fixture.get(range: 'bytes=0-15');
+        expect(retry.statusCode, HttpStatus.partialContent);
+        expect(await _readBody(retry), fixture.bytes);
       } finally {
         await fixture.close();
       }
@@ -74,7 +204,7 @@ void main() {
       bytes: List<int>.generate(64, (index) => index),
       totalBytes: 64,
       expectedBytes: 1000000,
-      maxResponseBytes: 16,
+      readChunkBytes: 16,
     );
     try {
       final response = await fixture.get(range: 'bytes=48-63');
@@ -95,7 +225,7 @@ void main() {
     final fixture = await _VideoServerFixture.create(
       bytes: List<int>.generate(64, (index) => index),
       totalBytes: 1000000,
-      maxResponseBytes: 16,
+      readChunkBytes: 16,
     );
     try {
       expect(fixture.uri.scheme, 'http');
@@ -121,7 +251,7 @@ void main() {
     final fixture = await _VideoServerFixture.create(
       bytes: List<int>.generate(128, (index) => index),
       totalBytes: 128,
-      maxResponseBytes: 16,
+      readChunkBytes: 16,
       queryBuilder: (file) {
         backend = _SparseRangeBackend(file: file, totalBytes: 128);
         return backend.query;
@@ -154,7 +284,7 @@ void main() {
     final fixture = await _VideoServerFixture.create(
       bytes: List<int>.generate(64, (index) => index),
       totalBytes: 64,
-      maxResponseBytes: 64,
+      readChunkBytes: 64,
       fileName: 'sample.webm',
       mimeType: 'video/webm',
     );
@@ -278,7 +408,7 @@ void main() {
       bytes: List<int>.generate(64, (index) => index),
       totalBytes: 1000000,
       reportedReadableBytes: 0,
-      maxResponseBytes: 16,
+      readChunkBytes: 16,
       queryBuilder: (file) {
         backend = _ControlledRangeBackend(file: file, totalBytes: 1000000);
         return backend.query;
@@ -316,7 +446,7 @@ void main() {
         bytes: List<int>.generate(64, (index) => index),
         totalBytes: 1000000,
         reportedReadableBytes: 0,
-        maxResponseBytes: 16,
+        readChunkBytes: 16,
         queryBuilder: (file) {
           backend = _ControlledRangeBackend(file: file, totalBytes: 1000000);
           return backend.query;
@@ -366,7 +496,7 @@ void main() {
       bytes: List<int>.generate(64, (index) => index),
       totalBytes: 1000000,
       reportedReadableBytes: 0,
-      maxResponseBytes: 16,
+      readChunkBytes: 16,
       queryBuilder: (file) {
         backend = _ControlledRangeBackend(file: file, totalBytes: 1000000);
         return backend.query;
@@ -432,7 +562,7 @@ void main() {
       bytes: const [],
       totalBytes: 1000000,
       reportedReadableBytes: 0,
-      maxResponseBytes: 16,
+      readChunkBytes: 16,
     );
     try {
       final response = await fixture.get(range: 'bytes=0-15');
@@ -452,7 +582,7 @@ void main() {
       bytes: const [1, 2, 3, 4],
       totalBytes: 1000000,
       reportedReadableBytes: 16,
-      maxResponseBytes: 16,
+      readChunkBytes: 16,
     );
     try {
       final response = await fixture.get(range: 'bytes=0-15');
@@ -470,7 +600,7 @@ void main() {
     final fixture = await _VideoServerFixture.create(
       bytes: List<int>.generate(256 * 1024, (index) => index % 251),
       totalBytes: 1000000,
-      maxResponseBytes: 256 * 1024,
+      readChunkBytes: 256 * 1024,
     );
     final cancelledClient = HttpClient();
     try {
@@ -499,7 +629,7 @@ void main() {
     final fixture = await _VideoServerFixture.create(
       bytes: List<int>.generate(64, (index) => index),
       totalBytes: 64,
-      maxResponseBytes: 16,
+      readChunkBytes: 16,
     );
     final preparation = Completer<bool>();
     try {
@@ -529,7 +659,7 @@ void main() {
     final fixture = await _VideoServerFixture.create(
       bytes: List<int>.generate(64, (index) => index),
       totalBytes: 64,
-      maxResponseBytes: 16,
+      readChunkBytes: 16,
     );
     try {
       fixture.server.holdRequestsUntilPrepared(Future<bool>.value(false));
@@ -573,7 +703,7 @@ final class _VideoServerFixture {
   static Future<_VideoServerFixture> create({
     required List<int> bytes,
     required int totalBytes,
-    required int maxResponseBytes,
+    required int readChunkBytes,
     int? expectedBytes,
     int? reportedReadableBytes,
     String? fileName,
@@ -596,7 +726,7 @@ final class _VideoServerFixture {
       query: queryBuilder?.call(file) ?? backend.query,
       fileName: fileName,
       mimeType: mimeType,
-      maxResponseBytes: maxResponseBytes,
+      readChunkBytes: readChunkBytes,
       rangeWaitTimeout: const Duration(milliseconds: 20),
       rangePollInterval: const Duration(milliseconds: 1),
     );
@@ -617,11 +747,15 @@ final class _VideoServerFixture {
     return getUri(uri, range: range);
   }
 
-  Future<HttpClientResponse> getUri(Uri target, {String? range}) async {
+  Future<HttpClientResponse> getUri(
+    Uri target, {
+    String? range,
+    String method = 'GET',
+  }) async {
     final client = HttpClient();
     _clients.add(client);
     try {
-      final request = await client.getUrl(target);
+      final request = await client.openUrl(method, target);
       if (range != null) {
         request.headers.set(HttpHeaders.rangeHeader, range);
       }


### PR DESCRIPTION
Requests such as `Range: bytes=0-` currently stop after 2 MiB, even when the requested span is much larger. Stream the complete requested span in one HTTP response while retaining bounded TDLib reads, so playback does not depend on the client issuing another request at every read boundary. Plain GET requests return the full representation, HEAD reports its size without downloading media bytes, and suffix ranges retain their requested length.

Validate the first chunk before sending successful headers, flush each chunk as it becomes available, and preserve the advertised length if a later chunk becomes unavailable so an interrupted transfer cannot look like a successfully completed short response.

### Validation

- All 24 video stream server tests pass. Added coverage includes open-ended and bounded ranges spanning multiple reads, suffix ranges, HEAD, progressive TDLib availability, and failure after the first chunk. The eight new or updated regression cases failed against the original implementation before the fix.
- 50 related player, download, account-scope, and mobile policy/widget tests pass. The remaining `scrub previews continue during a drag and recover after timeout` test also fails on unmodified `master` at `test/mobile_fullscreen_video_player_widget_test.dart:2295` (expected one thumbnail request, received zero).
- Targeted Flutter analysis, Dart formatting, and `git diff --check` pass.
- The project's pinned Windows MDK build decodes a synthetic 32-second video and starts decoding at 20 seconds with both the old and new servers.

### iOS verification pending

This is a candidate fix investigated after a report that chat videos on Mithka v1.3.0 / iOS 26.6.1 restart around 12–13 seconds and also restart when seeking beyond that point. The same response cap exists in v1.3.0, but the reported behavior has not been reproduced on an iPhone. The Windows comparison does not establish the cause of the iOS symptom; this PR should remain a draft pending device validation, including playback after a complete download and reopening the video.